### PR TITLE
Updated VMLRenderer to set position: relative if no position is set.

### DIFF
--- a/src/renderer/vml.js
+++ b/src/renderer/vml.js
@@ -61,6 +61,9 @@ define([
 
         this.container = container;
         this.container.style.overflow = 'hidden';
+        if (this.container.style.position === '') {
+            this.container.style.position = 'relative';
+        }
         this.container.onselectstart = function () {
             return false;
         };


### PR DESCRIPTION
Just replicating the same behaviour that is done in SVGRenderer and CanvasRenderer. 

As I had not loaded jsxgraph.css into the page, my constructions on IE8 were rendering away from their position due to the missing position:relative and the position:absolute on all the children.
