### PR TITLE
Fixing Env.isTouchEvent for IE8

### DIFF
--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -135,7 +135,7 @@ define(['jxg', 'utils/type'], function (JXG, Type) {
          * @returns {Boolean} True, if the browser supports touch events.
          */
         isTouchDevice: function () {
-            return this.isBrowser && document.documentElement.hasOwnProperty('ontouchstart');
+            return this.isBrowser && ('ontouchstart' in window);
         },
 
         /**


### PR DESCRIPTION
Using Modernizr's approach to detect touch events as in IE8 this method was throwing  "Object doesn't support this property or method". `hasOwnProperty` seems to be undefined for `document.documentElement`
