### PR TITLE
Fixing Text.updateSize when using the VMLRenderer and display === ‘html’

### DIFF
--- a/src/base/text.js
+++ b/src/base/text.js
@@ -297,7 +297,7 @@ define([
             if (!Env.isBrowser) {
                 return this;
             }
-            if (this.visProp.display === 'html' && this.board.renderer.type !== 'vml' && this.board.renderer.type !== 'no') {
+            if (this.visProp.display === 'html' && this.board.renderer.type !== 'no') {
                 s = [this.rendNode.offsetWidth, this.rendNode.offsetHeight];
                 if (s[0] === 0 && s[1] === 0) {
                     // Some browsers need some time to set offsetWidth and offsetHeight


### PR DESCRIPTION
This is applying the change suggested in my https://github.com/jsxgraph/jsxgraph/issues/64#issuecomment-28541778 after discovering [JXG.getDimensions](https://github.com/Learnosity/jsxgraph/blob/5d4073e/src/utils/env.js#L251-L253) has been using offsetWidth and offsetHeight for over 3 years.
