### PR TITLE
Search for expression if element is not found in ggb reader

### DIFF
--- a/src/reader/geogebra.js
+++ b/src/reader/geogebra.js
@@ -1698,6 +1698,9 @@
                         if (name === Data.getAttribute("label")) {
                             return Data;
                         }
+                        if (name === Data.getAttribute("exp")) {
+                            return this.getElement(Data.getAttribute("label"));
+                        }
                     }
                 }
             }
@@ -1733,7 +1736,7 @@
             // } else
 
             if (!JXG.exists(this.ggbElements[name]) || this.ggbElements[name] === '') {
-                input = this.getElement(name);
+                input = this.getElement(name) || this.getElement(name, true);
                 this.ggbElements[name] = this.writeElement(input);
             }
 


### PR DESCRIPTION
This fixes part of https://github.com/jsxgraph/jsxgraph/issues/99
A modified ggb where "A + b" and "b + A" are manually normalized.
https://drive.google.com/file/d/0B12AhxvnYHrAZlN4VlV4ejhrZ2s/edit?usp=sharing
The relevant xml:

``` xml
<expression label="C" exp="A + b" type="point" />
<element type="point" label="C">
    <show object="true" label="true"/>
    <objColor r="0" g="0" b="255" alpha="0.0"/>
    <layer val="0"/>
    <labelMode val="0"/>
    <coords x="5.0" y="3.0" z="1.0"/>
    <pointSize val="3"/>
    <pointStyle val="0"/>
</element>
<command name="Vector">
    <input a0="A" a1="A + b"/>
    <output a0="v"/>
</command>
```

When the reader parses the Vector v command, it searches for element with a label "A + b".
This PR also searches for an element which has an expression "A + b".
