### PR TITLE
Support hidden axes in the geogebra reader

### DIFF
--- a/src/reader/geogebra.js
+++ b/src/reader/geogebra.js
@@ -1865,9 +1865,14 @@
 
             grid = (evSettings.getAttribute("grid") === "true") ? this.board.create('grid') : null;
 
-            if (evSettings.getAttribute("axes") && evSettings.getAttribute("axes") === "true") {
-                this.ggbElements.xAxis = this.board.create('axis', [[0, 0], [1, 0]], {strokeColor: 'black', minorTicks: 0});
-                this.ggbElements.yAxis = this.board.create('axis', [[0, 0], [0, 1]], {strokeColor: 'black', minorTicks: 0});
+            if (evSettings.getAttribute("axes")) {
+                if(evSettings.getAttribute("axes") === "true") {
+                    this.ggbElements.xAxis = this.board.create('axis', [[0, 0], [1, 0]], {strokeColor: 'transparent', minorTicks: 0});
+                    this.ggbElements.yAxis = this.board.create('axis', [[0, 0], [0, 1]], {strokeColor: 'black', minorTicks: 0});
+                } else {
+                    this.ggbElements.xAxis = this.board.create('axis', [[0, 0], [1, 0]], {strokeColor: 'transparent', ticks: {drawLabels: false}});
+                    this.ggbElements.yAxis = this.board.create('axis', [[0, 0], [0, 1]], {strokeColor: 'transparent', ticks: {drawLabels: false}});
+                }
             }
         },
 


### PR DESCRIPTION
The geogebra reader need to create a hidden axis if an intersection point use it.
This fix the following example.
https://drive.google.com/file/d/0B12AhxvnYHrAYlhKaTRBLU9XNjA/edit?usp=sharing

Feel free to add it to the tests.
