### PR TITLE
Board.js: ignore touch move events triggered outside the board

### DIFF
--- a/src/base/board.js
+++ b/src/base/board.js
@@ -2013,7 +2013,7 @@ define([
          * @return {Boolean}
          */
         touchMoveListener: function (evt) {
-            var i, pos, time,
+            var i, pos1, pos2, time,
                 evtTouches = evt[JXG.touchProperty];
 
             if (this.mode !== this.BOARD_MODE_NONE) {
@@ -2051,25 +2051,28 @@ define([
                         // Touch by one finger:  this is possible for all elements that can be dragged
                         if (this.touches[i].targets.length === 1) {
                             if (evtTouches[this.touches[i].targets[0].num]) {
+                                pos1 = this.getMousePosition(evt, this.touches[i].targets[0].num);
+                                if (pos1[0] < 0 || pos1[0] > this.canvasWidth ||  pos1[1] < 0 || pos1[1] > this.canvasHeight) {
+                                    return;
+                                }
                                 this.touches[i].targets[0].X = evtTouches[this.touches[i].targets[0].num].screenX;
                                 this.touches[i].targets[0].Y = evtTouches[this.touches[i].targets[0].num].screenY;
-                                pos = this.getMousePosition(evt, this.touches[i].targets[0].num);
-                                this.moveObject(pos[0], pos[1], this.touches[i], evt, 'touch');
+                                this.moveObject(pos1[0], pos1[1], this.touches[i], evt, 'touch');
                             }
                             // Touch by two fingers: moving lines
                         } else if (this.touches[i].targets.length === 2 && this.touches[i].targets[0].num > -1 && this.touches[i].targets[1].num > -1) {
                             if (evtTouches[this.touches[i].targets[0].num] && evtTouches[this.touches[i].targets[1].num]) {
+                                pos1 = this.getMousePosition(evt, this.touches[i].targets[0].num);
+                                pos2 = this.getMousePosition(evt, this.touches[i].targets[1].num);
+                                if (pos1[0] < 0 || pos1[0] > this.canvasWidth ||  pos1[1] < 0 || pos1[1] > this.canvasHeight ||
+                                    pos2[0] < 0 || pos2[0] > this.canvasWidth ||  pos2[1] < 0 || pos2[1] > this.canvasHeight) {
+                                    return;
+                                }
                                 this.touches[i].targets[0].X = evtTouches[this.touches[i].targets[0].num].screenX;
                                 this.touches[i].targets[0].Y = evtTouches[this.touches[i].targets[0].num].screenY;
                                 this.touches[i].targets[1].X = evtTouches[this.touches[i].targets[1].num].screenX;
                                 this.touches[i].targets[1].Y = evtTouches[this.touches[i].targets[1].num].screenY;
-                                this.twoFingerMove(
-                                    this.getMousePosition(evt, this.touches[i].targets[0].num),
-                                    this.getMousePosition(evt, this.touches[i].targets[1].num),
-                                    this.touches[i],
-                                    evt
-                                );
-
+                                this.twoFingerMove(pos1, pos2, this.touches[i], evt);
                             }
                         }
                     }


### PR DESCRIPTION
Hi @migerh,

This is just a pull request to try bring feature parity between the behaviour of dragging a point with a mouse and on a touch device. 

Currently on touch devices it is possible to drag elements outside of the board and if released there, you have no way of retrieving them.
You can check this on the following example: http://goo.gl/smVWsT, just drag the point on a tablet outside of the board and release it.

This is due to the browser triggering touchmove even when outside the board container, which is not the case for mousemove.
We just added code to touchmove to check if we are within the board boundaries and if not, we ignore the event.

Cheers,
Sebastian
