### PR TITLE
Env.getDimensions now checks CSS styles when parent elements have display:none

### DIFF
--- a/src/utils/env.js
+++ b/src/utils/env.js
@@ -230,7 +230,8 @@ define(['jxg', 'utils/type'], function (JXG, Type) {
          */
         getDimensions: function (elementId, doc) {
             var element, display, els, originalVisibility, originalPosition,
-                originalDisplay, originalWidth, originalHeight;
+                originalDisplay, originalWidth, originalHeight, style,
+                pixelDimRegExp = /\d+(\.\d*)?px/;
 
             if (!JXG.isBrowser || elementId === null) {
                 return {
@@ -250,7 +251,15 @@ define(['jxg', 'utils/type'], function (JXG, Type) {
 
             // Work around a bug in Safari
             if (display !== 'none' && display !== null) {
-                return {width: element.offsetWidth, height: element.offsetHeight};
+                if (element.offsetWidth > 0 && element.offsetHeight > 0) {
+                    return {width: element.offsetWidth, height: element.offsetHeight};
+                } else { // a parent might be set to display:none; try reading them from styles
+                    style = window.getComputedStyle ? window.getComputedStyle(element) : element.style;
+                    return {
+                        width: pixelDimRegExp.test(style.width) ? parseFloat(style.width) : 0,
+                        height: pixelDimRegExp.test(style.height) ? parseFloat(style.height) : 0
+                    };
+                }
             }
 
             // All *Width and *Height properties give 0 on elements with display set to none,


### PR DESCRIPTION
Hi @alfredwassermann,

This is just a quick work around for when the board div is inside a parent with "display:none" set and there are either inline styles or from stylesheets defining the dimensions of the board.

The usual solution of navigating through all parents and changing their style to make them visible briefly to calculate the size and hiding them again could be quite costly depending on the DOM structure and number of boards on the page. As the board usually has dimensions specified, this seemed like an easy work around that would allow for correct rendering.

Cheers