### PR TITLE
Fixing IE8 bug with innerHTML

### DIFF
--- a/src/renderer/abstract.js
+++ b/src/renderer/abstract.js
@@ -632,7 +632,7 @@ define([
          * @see JXG.AbstractRenderer#updateTextStyle
          */
         updateText: function (el) {
-            var content = el.plaintext, v, c;
+            var content = el.plaintext, v, c, parentNode;
 
             if (el.visProp.visible) {
                 this.updateTextStyle(el, false);
@@ -691,7 +691,17 @@ define([
 
                     // Set the content
                     if (el.htmlStr !== content) {
-                        el.rendNode.innerHTML = content;
+                        try {
+                            el.rendNode.innerHTML = content;
+                        } catch (e) {
+                            // Setting innerHTML sometimes fails in IE8. A workaround is to
+                            // take the node off the DOM, assign innerHTML, then append back.
+                            // Works for text elements as they are absolutely positioned.
+                            parentNode = el.rendNode.parentNode;
+                            el.rendNode.parentNode.removeChild(el.rendNode);
+                            el.rendNode.innerHTML = content;
+                            parentNode.appendChild(el.rendNode);
+                        }
                         el.htmlStr = content;
 
                         if (el.visProp.usemathjax) {


### PR DESCRIPTION
@alfredwassermann: This pull requests applies a workaround only when an error is thrown while attempting to use `innerHTML`.

The `updateText` method of the Abstract Renderer attempts to set the text content by using `innerHTML`. 

This works fine almost everywhere, but we've found cases in which IE8 throws a `unknown runtime error`. According to documentation, the reason would be due to malformed content. But in all the failing tests, the content inserted was simple text (e.g. "0,0"). Also, if the sequence of steps leading to the Board rendering changed, the error was not thrown.

Remains a mystery why it happens, but going through jQuery code, I noticed that in their `html` function, they surround the call to `innerHTML` with a try/catch and fall back to a more complex method of adding the content by programmatically creating the elements.

I've found that in the cases this fails, if the node is removed form the DOM, then IE8 allows `innerHTML` to be modified and doesn't error when appending back the node. As text elements are absolutely positioned within the board, removing the node and appending it has no complications as we are not relying on DOM placement for positioning. 