### PR TITLE
New setLabel function that creates a label if missing before setting text

### DIFF
--- a/src/base/element.js
+++ b/src/base/element.js
@@ -239,7 +239,7 @@ define([
          * @type Object
          */
         this.methodMap = {
-            setLabel: 'setLabelText',
+            setLabel: 'setLabel',
             label: 'label',
             setName: 'setName',
             getName: 'getName',
@@ -807,6 +807,18 @@ define([
                 }
             }
             return properties;
+        },
+
+        /**
+         * Sets a label and it's text
+         * If label doesn't exist, it creates one
+         * @param {String} str
+         */
+        setLabel: function (str) {
+            if (!this.hasLabel) {
+                this.setAttribute({'withlabel': true});
+            }
+            this.setLabelText(str);
         },
 
         /**
@@ -1567,7 +1579,7 @@ define([
                 }
             }
             */
-            
+
             if (needsSnapToGrid) {
                 x = this.coords.usrCoords[1];
                 y = this.coords.usrCoords[2];


### PR DESCRIPTION
When using JessieCode and calling `setLabel`, if the element doesn't have a label, nothing happens.

I've created a new "setLabel" function that will create a label for the element if it doesn't have one, before calling `setLabelText`. When parsing JessieCode, this function will be called instead and the behaviour would be more intuitive.