### PR TITLE
Board selection

### DIFF
--- a/src/base/board.js
+++ b/src/base/board.js
@@ -522,6 +522,28 @@ define([
          */
         this._drag_offset = [0, 0];
 
+        /**
+         * A flag which tells us if the board is in the selecting mode
+         * @type {Boolean}
+         * @default false
+         */
+        this.selectingMode = false;
+
+        /**
+         * A flag which tells us if the user is selecting
+         * @type {Boolean}
+         * @default false
+         */
+        this.isSelecting = false;
+	
+        /**
+         * A bounding box for the selection
+         * @type {Array}
+         * @default [ [0,0], [0,0] ]
+         */
+        this.selectingBox = [ [0,0], [0,0] ];
+
+	
         if (this.attr.registerevents) {
             this.addEventHandlers();
         }
@@ -2308,6 +2330,13 @@ define([
                 }
             }
 
+    	    // selection
+	    if(this.selectingMode) {
+		this.isSelecting = true;
+                this.selectingBox = [ [pos[0], pos[1]], [pos[0], pos[1]] ];
+		this.triggerEventHandlers(['mousestartselecting', 'startselecting'], [evt]);
+	    }
+
             if (this.mode === this.BOARD_MODE_NONE) {
                 result = this.mouseOriginMoveStart(evt);
             }
@@ -2322,7 +2351,7 @@ define([
          * @param {Event} evt
          */
         mouseUpListener: function (evt) {
-            var i;
+            var i, pos;
 
             this.triggerEventHandlers(['mouseup', 'up'], [evt]);
 
@@ -2339,6 +2368,14 @@ define([
             this.dehighlightAll();
             this.update();
 
+	    // selection
+	    if(this.selectingMode) {
+                pos = this.getMousePosition(evt);
+		this.isSelecting = false;
+                this.selectingBox[1] = [pos[0], pos[1]];
+		this.triggerEventHandlers(['mousestopselecting', 'stopselecting'], [evt]);
+	    }
+	    
             for (i = 0; i < this.downObjects.length; i++) {
                 this.downObjects[i].triggerEventHandlers(['mouseup', 'up'], [evt]);
             }
@@ -2383,6 +2420,12 @@ define([
                     this.highlightElements(pos[0], pos[1], evt, -1);
                 }
             }
+
+	    // selection
+	    if(this.selectingMode) {
+		this.isSelecting = false;
+                this.selectingBox[1] = [pos[0], pos[1]];
+	    }
 
             this.updateQuality = this.BOARD_QUALITY_HIGH;
 
@@ -4090,6 +4133,16 @@ define([
             this.cssTransMat = Mat.inverse(this.cssTransMat);
 
             return this;
+        },
+
+        startSelectionMode: function () {
+          this.selectingMode = true;
+	  this.selectingBox = [ [0,0], [0,0] ];
+        },
+
+        stopSelectionMode: function () {
+          this.selectingMode = false;
+	  return this.selectingBox;
         },
 
 

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -2334,6 +2334,7 @@ define([
 	    if(this.selectingMode) {
 		this.isSelecting = true;
                 this.selectingBox = [ [pos[0], pos[1]], [pos[0], pos[1]] ];
+		this._setSelectionPolygonFromBox()
 		this.triggerEventHandlers(['mousestartselecting', 'startselecting'], [evt]);
 	    }
 
@@ -2373,6 +2374,7 @@ define([
                 pos = this.getMousePosition(evt);
 		this.isSelecting = false;
                 this.selectingBox[1] = [pos[0], pos[1]];
+		this._setSelectionPolygonFromBox()
 		this.triggerEventHandlers(['mousestopselecting', 'stopselecting'], [evt]);
 	    }
 	    
@@ -2424,12 +2426,23 @@ define([
 	    // selection
 	    if(this.selectingMode && this.isSelecting) {
                 this.selectingBox[1] = [pos[0], pos[1]];
+		this._setSelectionPolygonFromBox()
+		this.selection.prepareUpdate().update().updateRenderer()
 	    }
 
             this.updateQuality = this.BOARD_QUALITY_HIGH;
 
             this.triggerEventHandlers(['mousemove', 'move'], [evt, this.mode]);
         },
+
+	_setSelectionPolygonFromBox() {
+	    var A = this.selectingBox[0];
+	    var B = this.selectingBox[1];
+	    this.selection.vertices[0].setPositionDirectly(JXG.COORDS_BY_SCREEN, [A[0], A[1]]);
+	    this.selection.vertices[1].setPositionDirectly(JXG.COORDS_BY_SCREEN, [A[0], B[1]]);
+	    this.selection.vertices[2].setPositionDirectly(JXG.COORDS_BY_SCREEN, [B[0], B[1]]);
+	    this.selection.vertices[3].setPositionDirectly(JXG.COORDS_BY_SCREEN, [B[0], A[1]]);
+	},
 
         /**
          * Handler for mouse wheel events. Used to zoom in and out of the board.
@@ -4136,11 +4149,15 @@ define([
 
         startSelectionMode: function () {
           this.selectingMode = true;
+	  this.selection.setAttribute({visible: true});
 	  this.selectingBox = [ [0,0], [0,0] ];
+	  this._setSelectionPolygonFromBox()
+          this.selection.prepareUpdate().update().updateRenderer()
         },
 
         stopSelectionMode: function () {
           this.selectingMode = false;
+  	  this.selection.setAttribute({visible: false});
 	  return this.selectingBox;
         },
 

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -2422,8 +2422,7 @@ define([
             }
 
 	    // selection
-	    if(this.selectingMode) {
-		this.isSelecting = false;
+	    if(this.selectingMode && this.isSelecting) {
                 this.selectingBox[1] = [pos[0], pos[1]];
 	    }
 

--- a/src/jsxgraph.js
+++ b/src/jsxgraph.js
@@ -245,6 +245,9 @@ define([
                 board.create('grid', [], (typeof attr.grid === 'object' ? attr.grid : {}));
             }
 
+    	    var selectionattr = { withLines: false, vertices: { visible: false }, visible: false };
+	    board.selection = board.create('polygon', [[0, 0], [0, 0], [0, 0], [0, 0]], selectionattr);
+
             board.renderer.drawZoomBar(board);
             board.unsuspendUpdate();
 


### PR DESCRIPTION
 Allow a graph to be in a selectionMode by calling the function board.startSelectionMode().
Once in this mode, the mouse allow to draw a rectangle selection on the board.
Other mouse action, such as moving a point is disabled.
To stop selectingMode, the function board.stopSelectionMode() must be called.
At any time, board.selectingBox gives mouse coordinates of the selection.
