### PR TITLE
Support child arrays for cmpArrays().

### DIFF
--- a/src/utils/type.js
+++ b/src/utils/type.js
@@ -535,7 +535,12 @@ define([
             }
 
             for (i = 0; i < a1.length; i++) {
-                if (a1[i] !== a2[i]) {
+                if (JXG.isArray(a1[i]) && JXG.isArray(a2[i])) {
+                    if (!cmpArrays(a1[i], a2[i])) {
+                        return false;
+                    }
+                }
+                else if (a1[i] !== a2[i]) {
                     return false;
                 }
             }

--- a/src/utils/type.js
+++ b/src/utils/type.js
@@ -535,8 +535,8 @@ define([
             }
 
             for (i = 0; i < a1.length; i++) {
-                if (JXG.isArray(a1[i]) && JXG.isArray(a2[i])) {
-                    if (!cmpArrays(a1[i], a2[i])) {
+                if (this.isArray(a1[i]) && this.isArray(a2[i])) {
+                    if (!this.cmpArrays(a1[i], a2[i])) {
                         return false;
                     }
                 }


### PR DESCRIPTION
For example:

var a1 = [[0,0], [1,3], [3,2], [4,2]],
      a2 = [[0,0], [1,3], [3,2], [4,2]];
if (JXG.cmpArrays(a1, a2)) {}