### PR TITLE
Minor bug fix in initialisation of curve plotting

### DIFF
--- a/src/base/curve.js
+++ b/src/base/curve.js
@@ -1348,7 +1348,6 @@ define([
             this.nanLevel = depth - 4;
 
             this.points = [];
-            this._lastCrds = [0, NaN, NaN];   // Used in _insertPoint
 
             ta = mi;
             pa.setCoordinates(Const.COORDS_BY_USER, [this.X(ta, suspendUpdate), this.Y(ta, suspendUpdate)], false);
@@ -1360,6 +1359,7 @@ define([
             b = pb.copy('scrCoords');
 
             this.points.push(pa);
+            this._lastCrds = pa.copy('scrCoords');   //Used in _insertPoint
             this._plotRecursive(a, ta, b, tb, depth, delta);
             this.points.push(pb);
 //console.log("NUmber points", this.points.length, this.board.updateQuality, this.board.BOARD_QUALITY_LOW);


### PR DESCRIPTION
The _lastCrds variable in curve was being set to [NaN,NaN] rather than
the initially added point. This meant that if the first point evaluated
was a discontinuity the value of [NaN,NaN] would not be added to the
list of points as this appeared to be the last point (and as such would
be omitted to avoid repitition). As a result the discontinuity would be plotted.