### PR TITLE
write attributes properties in JSDoc notation

### DIFF
--- a/src/jsxgraph.js
+++ b/src/jsxgraph.js
@@ -158,18 +158,16 @@ define([
         /**
          * Initialise a new board.
          * @param {String} box Html-ID to the Html-element in which the board is painted.
-         * @param {Object} attributes An object that sets some of the board properties. Most of these properties can be set via JXG.Options. Valid properties are
-         * <ul>
-         *     <li><b>boundingbox</b>: An array containing four numbers describing the left, top, right and bottom boundary of the board in user coordinates</li>
-         *     <li><b>keepaspectratio</b>: If <tt>true</tt>, the bounding box is adjusted to the same aspect ratio as the aspect ratio of the div containing the board.</li>
-         *     <li><b>showCopyright</b>: Show the copyright string in the top left corner.</li>
-         *     <li><b>showNavigation</b>: Show the navigation buttons in the bottom right corner.</li>
-         *     <li><b>zoom</b>: Allow the user to zoom with the mouse wheel or the two-fingers-zoom gesture.</li>
-         *     <li><b>pan</b>: Allow the user to pan with shift+drag mouse or two-fingers-pan gesture.</li>
-         *     <li><b>axis</b>: If set to true, show the axis. Can also be set to an object that is given to both axes as an attribute object.</li>
-         *     <li><b>grid</b>: If set to true, shows the grid. Can also bet set to an object that is given to the grid as its attribute object.</li>
-         *     <li><b>registerEvents</b>: Register mouse / touch events.</li>
-         * </ul>
+         * @param {Object} attributes An object that sets some of the board properties. Most of these properties can be set via JXG.Options.
+         * @param {Array} [attributes.boundingbox=[-5, 5, 5, -5]] An array containing four numbers describing the left, top, right and bottom boundary of the board in user coordinates
+         * @param {Boolean} [attributes.keepaspectratio=false] If <tt>true</tt>, the bounding box is adjusted to the same aspect ratio as the aspect ratio of the div containing the board.
+         * @param {Boolean} [attributes.showCopyright=false] Show the copyright string in the top left corner.
+         * @param {Boolean} [attributes.showNavigation=false] Show the navigation buttons in the bottom right corner.
+         * @param {Object} [attributes.zoom] Allow the user to zoom with the mouse wheel or the two-fingers-zoom gesture.
+         * @param {Object} [attributes.pan] Allow the user to pan with shift+drag mouse or two-fingers-pan gesture.
+         * @param {Boolean} [attributes.axis=false] If set to true, show the axis. Can also be set to an object that is given to both axes as an attribute object.
+         * @param {Boolean|Object} [attributes.grid] If set to true, shows the grid. Can also bet set to an object that is given to the grid as its attribute object.
+         * @param {Boolean} [attributes.registerEvents=true] Register mouse / touch events.
          * @returns {JXG.Board} Reference to the created board.
          */
         initBoard: function (box, attributes) {


### PR DESCRIPTION
This allows tools to autocomplete, and so prevent typos:
![image](https://cloud.githubusercontent.com/assets/1035299/19626080/331617e0-9929-11e6-88fe-7fd2a4c7f724.png)
