### PR TITLE
use regularPolygons' default attributes

### DIFF
--- a/src/base/polygon.js
+++ b/src/base/polygon.js
@@ -1021,7 +1021,7 @@ define([
             }
         }
 
-        attr = Type.copyAttributes(attributes, board.options, 'polygon');
+        attr = Type.copyAttributes(attributes, board.options, 'regularpolygon');
         el = board.create('polygon', p, attr);
         el.elType = 'regularpolygon';
 


### PR DESCRIPTION
Regular polygons were created with default attributes (options) of a normal polygon, instead the ones of a regular polygon.