### PR TITLE
disable text selection on navigation bar

### DIFF
--- a/src/renderer/canvas.js
+++ b/src/renderer/canvas.js
@@ -78,6 +78,7 @@ define([
         if (Env.isBrowser) {
             this.container = container;
             this.container.style.MozUserSelect = 'none';
+            this.container.style.userSelect = 'none';
 
             this.container.style.overflow = 'hidden';
             if (this.container.style.position === '') {

--- a/src/renderer/svg.js
+++ b/src/renderer/svg.js
@@ -94,6 +94,7 @@ define([
 
         // prepare the div container and the svg root node for use with JSXGraph
         this.container.style.MozUserSelect = 'none';
+        this.container.style.userSelect = 'none';
 
         this.container.style.overflow = 'hidden';
         if (this.container.style.position === '') {


### PR DESCRIPTION
If I click repeatedly on the zoom or arrow buttons, they will be highlighted.  Using the css user-select property disables this highlighting.