### PR TITLE
_setUpdateText casts value to string

### DIFF
--- a/src/base/text.js
+++ b/src/base/text.js
@@ -182,10 +182,11 @@ define([
             this.orgText = text;
             if (Type.isFunction(text)) {
                 this.updateText = function () {
+                    var resolvedText = text().toString();
                     if (this.visProp.parse && !this.visProp.usemathjax) {
-                        this.plaintext = this.replaceSub(this.replaceSup(this.convertGeonext2CSS(text())));
+                        this.plaintext = this.replaceSub(this.replaceSup(this.convertGeonext2CSS(resolvedText)));
                     } else {
-                        this.plaintext = text();
+                        this.plaintext = resolvedText;
                     }
                 };
             } else if (Type.isString(text) && !this.visProp.parse) {


### PR DESCRIPTION
When the content of a text element is given as a function, always cast
it to a string.

fixes #223