### PR TITLE
line.hasPoint(): fix typo in var name

### DIFF
--- a/src/base/line.js
+++ b/src/base/line.js
@@ -187,7 +187,7 @@ define([
                 return false;
             }
 
-            if (Type.evaluate(this.visProp.straightfirs) &&
+            if (Type.evaluate(this.visProp.straightfirst) &&
                     Type.evaluate(this.visProp.straightlast)) {
                 return true;
             }


### PR DESCRIPTION
hasPoint() references visProp.straightfirs, but this isn't defined. It should be visProp.straightfirst.