### PR TITLE
docs: change "Hashes" to "Hatches".

### DIFF
--- a/JSXCompressor/jsxgraphcore.js
+++ b/JSXCompressor/jsxgraphcore.js
@@ -54000,7 +54000,7 @@ define('base/ticks',[
     };
 
     /**
-     * @class Hashes can be used to mark congruent lines.
+     * @class Hatches can be used to mark congruent lines.
      * @pseudo
      * @description
      * @name Hatch

--- a/src/base/ticks.js
+++ b/src/base/ticks.js
@@ -1137,7 +1137,7 @@ define([
     };
 
     /**
-     * @class Hashes can be used to mark congruent lines.
+     * @class Hatches can be used to mark congruent lines.
      * @pseudo
      * @description
      * @name Hatch


### PR DESCRIPTION
I'm pretty sure the plural of hatch is hatches, not hashes.