### PR TITLE
Geogebra reader: Fix argument order when mirroring across line

### DIFF
--- a/src/reader/geogebra.js
+++ b/src/reader/geogebra.js
@@ -2380,7 +2380,7 @@
 
                 try {
                     JXG.debug("* Mirror: First: " + input[0].name + ", Second: " + input[1].name);
-                    p = this.board.create(type, [input[1], input[0]], attr);
+                    p = this.board.create(type, [input[0], input[1]], attr);
                     return p;
                 } catch (exc12) {
                     JXG.debug("* Err: Mirror " + attr.name);


### PR DESCRIPTION
As it is right now, it errors out when trying to do something like mirroring points across a line, since it expexts the mirrored object to be the first argument

Should I be mirroring these changes to the built reader in `distrib/`?