### PR TITLE
compile error fix: Update canvas dependency to 1.6.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "requirejs": "2.3.x"
   },
   "optionalDependencies": {
-    "canvas": "1.3.x"
+    "canvas": "1.6.x"
   },
   "devDependencies": {
     "almond": ">=0.3.x",


### PR DESCRIPTION
This fixes some compile errors I'm seeing with canvas 1.3.16:

```
../src/Canvas.cc: In static member function ‘static Nan::NAN_METHOD_RETURN_TYPE Canvas::StreamPNGSync(Nan::NAN_METHOD_ARGS_TYPE)’:                                                              
../src/Canvas.cc:417:12: error: no matching function for call to ‘v8::TryCatch::TryCatch()’                                                                                                     
   TryCatch try_catch;   

../src/Canvas.cc: In static member function ‘static Nan::NAN_METHOD_RETURN_TYPE Canvas::StreamJPEGSync(Nan::NAN_METHOD_ARGS_TYPE)’:                                                             
../src/Canvas.cc:458:12: error: no matching function for call to ‘v8::TryCatch::TryCatch()’                                                                                                     
   TryCatch try_catch;    
```

See: https://github.com/jsxgraph/jsxgraph/issues/225