### PR TITLE
Beautify scientific tick labels

### DIFF
--- a/src/base/ticks.js
+++ b/src/base/ticks.js
@@ -1008,6 +1008,9 @@ define([
                         labelText.indexOf('e') !== -1) {
                     labelText = value.toPrecision(Type.evaluate(this.visProp.precision)).toString();
                 }
+
+                labelText = this.beautifyScientificNotationLabel(labelText);
+
                 if (labelText.indexOf('.') > -1 && labelText.indexOf('e') === -1) {
                     // trim trailing zeros
                     labelText = labelText.replace(/0+$/, '');
@@ -1030,6 +1033,47 @@ define([
                 labelText = labelText.replace(/-/g, '\u2212');
             }
             return labelText;
+        },
+
+        /**
+         * Formats label texts to make labels displayed in scientific notation look beautiful.
+         * For example, label 5.00e+6 will become 5•10⁶, label -1.00e-7 will become into -1•10⁻⁷
+         * @param {String} labelText - The label that we want to convert
+         * @returns {String} If labelText was not in scientific notation, return labelText without modifications.
+         * Otherwise returns beautified labelText with proper superscript notation.
+         */
+        beautifyScientificNotationLabel: function(labelText) {
+            if (labelText.indexOf('e') === -1) {
+                return labelText;
+            }
+
+            // Clean up trailing 0`s, so numbers like 5.00e+6.0 for example become into 5e+6
+            let returnString = parseFloat(labelText.substring(0, labelText.indexOf('e')))
+                + labelText.substring(labelText.indexOf('e'))
+
+            // Replace symbols like -,0,1,2,3,4,5,6,7,8,9 with their superscript version.
+            // Gets rid of + symbol since there is no need for it anymore.
+            returnString = returnString.replace(/e(.*)$/g, function(match,$1){
+                let temp = '\u2022' + '10';
+
+                temp +=  $1
+                    .replace(/-/g, "\u207B")
+                    .replace(/\+/g, '')
+                    .replace(/0/g,'\u2070')
+                    .replace(/1/g,'\u00B9')
+                    .replace(/2/g,'\u00B2')
+                    .replace(/3/g,'\u00B3')
+                    .replace(/4/g,'\u2074')
+                    .replace(/5/g,'\u2075')
+                    .replace(/6/g,'\u2076')
+                    .replace(/7/g,'\u2077')
+                    .replace(/8/g,'\u2078')
+                    .replace(/9/g,'\u2079');
+
+                return temp;
+            });
+
+            return returnString;
         },
 
         /**

--- a/src/base/ticks.js
+++ b/src/base/ticks.js
@@ -1009,7 +1009,7 @@ define([
                     labelText = value.toPrecision(Type.evaluate(this.visProp.precision)).toString();
                 }
 
-                if (this.board.options.board.beautifyScientificNotationLabel) {
+                if (this.board.options.board.beautifulScientificTickLabels) {
                     labelText = this.beautifyScientificNotationLabel(labelText);
                 }
 
@@ -1057,7 +1057,8 @@ define([
             // Gets rid of + symbol since there is no need for it anymore.
             returnString = returnString.replace(/e(.*)$/g, function(match,$1){
                 let temp = '\u2022' + '10';
-
+                // Note: Since board ticks do not support HTTP elements like <sub>, we need to replace
+                // all the numbers with superscript Unicode characters.
                 temp +=  $1
                     .replace(/-/g, "\u207B")
                     .replace(/\+/g, '')

--- a/src/base/ticks.js
+++ b/src/base/ticks.js
@@ -1009,7 +1009,9 @@ define([
                     labelText = value.toPrecision(Type.evaluate(this.visProp.precision)).toString();
                 }
 
-                labelText = this.beautifyScientificNotationLabel(labelText);
+                if (this.board.options.board.beautifyScientificNotationLabel) {
+                    labelText = this.beautifyScientificNotationLabel(labelText);
+                }
 
                 if (labelText.indexOf('.') > -1 && labelText.indexOf('e') === -1) {
                     // trim trailing zeros

--- a/src/options.js
+++ b/src/options.js
@@ -320,7 +320,7 @@ define([
             showFullscreen: false,
 
             /**
-             * Attribute(s) to control the fullscreen icon. The attribute "showFullscreen" 
+             * Attribute(s) to control the fullscreen icon. The attribute "showFullscreen"
              * controls if the icon is shown.
              * The following attribute(s) can be set:
              * <ul>
@@ -362,7 +362,7 @@ define([
             },
 
             /**
-             * Show a button which allows to clear all traces of a board. 
+             * Show a button which allows to clear all traces of a board.
              *
              * @name JXG.Board#showClearTraces
              * @type Boolean
@@ -653,7 +653,17 @@ define([
                 },
                 fillColor: '#ffff00',
                 visible: false
-            }
+            },
+
+            /**
+             * Format tick labels that were going to have scientific notation
+             * like 5.00e+6 to look like 5•10⁶.
+             *
+             * @name JXG.Board#beautifulScientificTickLabels
+             * @type Boolean
+             * @default false
+             */
+            beautifulScientificTickLabels: false
             /**#@-*/
         },
 
@@ -861,7 +871,7 @@ define([
              *                 gradientEndOffset: function() { return o2.Value(); },
              *                 hasInnerPoints: true
              *     });
-             * 
+             *
              * </pre><div id="JXG6081ca7f-0d09-4525-87ac-325a02fe2225" class="jxgbox" style="width: 300px; height: 300px;"></div>
              * <script type="text/javascript">
              *     (function() {
@@ -889,11 +899,11 @@ define([
              *                     gradientEndOffset: function() { return o2.Value(); },
              *                     hasInnerPoints: true
              *         });
-             * 
+             *
              *     })();
-             * 
+             *
              * </script><pre>
-             * 
+             *
              *
              * @type String
              * @name JXG.GeometryElement#gradient


### PR DESCRIPTION
Added an option to beautify scientific tick labels. 

This change will allow ticks labels like 5.00e+6 to look like 5•10⁶, which is much more pleasant to the eye and does not clutter the graph.

Added a new option JXG.Options.board.beautifulScientificTickLabels (false by default) that can be set to true to enable this change.

Feel free to set the default to true if this pull is accepted and if setting it to true is appropriate.

Please check the visual change that this pull adds.

[https://ibb.co/2kyjJqm](url)