### PR TITLE
Fix generateGaussian function

### DIFF
--- a/src/math/statistics.js
+++ b/src/math/statistics.js
@@ -496,7 +496,7 @@ define(['jxg', 'math/math', 'utils/type'], function (JXG, Mat, Type) {
 
             if (this.hasSpare) {
                 this.hasSpare = false;
-                return this.spare * stdDev + this.mean;
+                return this.spare * stdDev + mean;
             }
 
             do {


### PR DESCRIPTION
The generateGaussian function was returning a string instead of a number every other sample, because it was using the mean _function_ instead of the mean _value_ when using the spare.