### PR TITLE
Prevent image reload on every update in svgRenderer

### DIFF
--- a/src/renderer/svg.js
+++ b/src/renderer/svg.js
@@ -591,7 +591,15 @@ define([
         updateImageURL: function (el) {
             var url = Type.evaluate(el.url);
 
-            el.rendNode.setAttributeNS(this.xlinkNamespace, 'xlink:href', url);
+            if (el._src !== url) {
+                el.imgIsLoaded = false;
+                el.rendNode.setAttributeNS(this.xlinkNamespace, 'xlink:href', url);
+                el._src = url;
+
+                return true;
+            }
+
+            return false;
         },
 
         // already documented in JXG.AbstractRenderer


### PR DESCRIPTION
Whilst inspecting the network usage using images, it appeared that the image is reloaded upon every update, causing a flickering effect in at least the Chrome browser. The issue is resolved by adding a similarity url check as is the case for the canvas renderer.