### PR TITLE
Fix Example in Docs

### DIFF
--- a/src/base/point.js
+++ b/src/base/point.js
@@ -434,11 +434,11 @@ define([
      * </pre><div class="jxgbox" id="JXG4de7f181-631a-44b1-a12f-bc4d133709e8" style="width: 200px; height: 200px;"></div>
      * <script type="text/javascript">
      *   var gpex3_board = JXG.JSXGraph.initBoard('JXG4de7f181-631a-44b1-a12f-bc4d133709e8', {boundingbox: [-1, 10, 10, -1], axis: true, showcopyright: false, shownavigation: false});
-     *   var gpex3_p1 = gpex2_board.create('point', [2.0, 2.0]);
-     *   var gpex3_c1 = gpex2_board.create('circle', [gpex2_p1, 2.0]);
-     *   var gpex3_p2 = gpex2_board.create('glider', [gpex2_c1]);
-     *   board.create('button', [1, 7, 'start animation',function(){gpex3_p2.startAnimation(1,4)}]);
-     *   board.create('button', [1, 5, 'stop animation',function(){gpex3_p2.stopAnimation()}]);
+     *   var gpex3_p1 = gpex3_board.create('point', [2.0, 2.0]);
+     *   var gpex3_c1 = gpex3_board.create('circle', [gpex3_p1, 2.0]);
+     *   var gpex3_p2 = gpex3_board.create('glider', [gpex3_c1]);
+     *   gpex3_board.create('button', [1, 7, 'start animation',function(){gpex3_p2.startAnimation(1,4)}]);
+     *   gpex3_board.create('button', [1, 5, 'stop animation',function(){gpex3_p2.stopAnimation()}]);
      * </script><pre>
      */
     JXG.createGlider = function (board, parents, attributes) {


### PR DESCRIPTION
The third example in the docs (https://jsxgraph.uni-bayreuth.de/docs/symbols/Glider.html) was not working.
This PR should fix that