### PR TITLE
Fixed Description

### DIFF
--- a/src/element/sector.js
+++ b/src/element/sector.js
@@ -64,7 +64,7 @@ define([
      * @throws {Error} If the element cannot be constructed with the given parent objects an exception is thrown.
      *
      * First possiblity of input parameters are:
-     * @param {JXG.Point_JXG.Point_JXG.Point} p1,p2,p1 A sector is defined by three points: The sector's center <tt>p1</tt>,
+     * @param {JXG.Point_JXG.Point_JXG.Point} p1,p2,p3 A sector is defined by three points: The sector's center <tt>p1</tt>,
      * a second point <tt>p2</tt> defining the radius and a third point <tt>p3</tt> defining the angle of the sector. The
      * Sector is always drawn counter clockwise from <tt>p2</tt> to <tt>p3</tt>
      * <p>


### PR DESCRIPTION
I believe this should be p1,p2,p3 instead of p1,p2,p1 when it's refered to "a third point" and "p3" in the text.