### PR TITLE
add attractToGrid attribute for points

### DIFF
--- a/src/base/element.js
+++ b/src/base/element.js
@@ -1977,12 +1977,15 @@ define([
          * @returns {JXG.GeometryElement} Reference to this element
          */
         handleSnapToGrid: function (force, fromParent) {
-            var x, y, ticks,
+            var x, y, ticks, rx, ry, rcoords,
                 //i, len, g, el, p,
                 boardBB,
                 needsSnapToGrid = false,
                 sX = Type.evaluate(this.visProp.snapsizex),
-                sY = Type.evaluate(this.visProp.snapsizey);
+                sY = Type.evaluate(this.visProp.snapsizey),
+                attractToGrid = Type.evaluate(this.visProp.attracttogrid),
+                ev_au = Type.evaluate(this.visProp.attractorunit),
+                ev_ad = Type.evaluate(this.visProp.attractordistance);
 
             if (!Type.exists(this.coords)) {
                 return this;
@@ -2007,25 +2010,29 @@ define([
                 // if no valid snap sizes are available, don't change the coords.
                 if (sX > 0 && sY > 0) {
                     boardBB = this.board.getBoundingBox();
-                    x = Math.round(x / sX) * sX;
-                    y = Math.round(y / sY) * sY;
+                    rx = Math.round(x / sX) * sX;
+                    ry = Math.round(y / sY) * sY;
+                    rcoords = new JXG.Coords(Const.COORDS_BY_USER, [rx,ry], this.board);
+                    if(!attractToGrid || rcoords.distance(ev_au == 'screen' ? Const.COORDS_BY_SCREEN : Const.COORDS_BY_USER, this.coords)<ev_ad) {
+                        x = rx;
+                        y = ry;
+                        // checking whether x and y are still within boundingBox,
+                        // if not, adjust them to remain within the board
+                        if (!fromParent) {
+                            if (x < boardBB[0]) {
+                                x += sX;
+                            } else if (x > boardBB[2]) {
+                                x -= sX;
+                            }
 
-                    // checking whether x and y are still within boundingBox,
-                    // if not, adjust them to remain within the board
-                    if (!fromParent) {
-                        if (x < boardBB[0]) {
-                            x += sX;
-                        } else if (x > boardBB[2]) {
-                            x -= sX;
+                            if (y < boardBB[3]) {
+                                y += sY;
+                            } else if (y > boardBB[1]) {
+                                y -= sY;
+                            }
                         }
-
-                        if (y < boardBB[3]) {
-                            y += sY;
-                        } else if (y > boardBB[1]) {
-                            y -= sY;
-                        }
+                        this.coords.setCoordinates(Const.COORDS_BY_USER, [x, y]);
                     }
-                    this.coords.setCoordinates(Const.COORDS_BY_USER, [x, y]);
                 }
             }
             return this;

--- a/src/options.js
+++ b/src/options.js
@@ -3988,6 +3988,19 @@ define([
             snapToGrid: false,
 
             /**
+             * If set to true, the point will only snap to the grid when within {@link Point#attractorDistance} of a grid point.
+             *
+             * @name Point#attractToGrid
+             *
+             * @see Point#attractorDistance
+             * @see Point#attractorUnit
+             * @see Point#snapToGrid
+             * @type Boolean
+             * @default false
+             */
+            attractToGrid: false,
+
+            /**
              * Defines together with {@link Point#snapSizeY} the grid the point snaps on to.
              * The point will only snap on integer multiples to snapSizeX in x and snapSizeY in y direction.
              * If this value is equal to or less than <tt>0</tt>, it will use the grid displayed by the major ticks


### PR DESCRIPTION
I'd like to replicate GeoGebra's behaviour when dragging points, where they snap to the grid only when within a certain distance in screen space. If this is already possible, please tell me how!

This PR adds a new attribute `attractToGrid` for points.

If attractToGrid and snapToGrid are true, then points will only snap to
the grid if they are within the distance defined by attractorUnit and
attractorDistance.

Setting attractorUnit to 'screen' replicates the behaviour of GeoGebra.

I don't know if it's OK to reuse attractorUnit and attractorDistance, or if it should be possible to set different distances for attracting to points and to the grid.