### PR TITLE
attractToGrid can be enabled without snapToGrid

### DIFF
--- a/src/base/element.js
+++ b/src/base/element.js
@@ -1991,7 +1991,7 @@ define([
                 return this;
             }
 
-            needsSnapToGrid = Type.evaluate(this.visProp.snaptogrid) || force === true;
+            needsSnapToGrid = Type.evaluate(this.visProp.snaptogrid) || attractToGrid || force === true;
 
             if (needsSnapToGrid) {
                 x = this.coords.usrCoords[1];


### PR DESCRIPTION
see #378 - this changes the behaviour of the `attractToGrid` setting so it doesn't need `snapToGrid` to also be enabled, and `attractToGrid` takes precedence when both are enabled.