### PR TITLE
JessieCode: if no attributes given to an object, its name is the LHS of the assignment

### DIFF
--- a/src/parser/jessiecode.js
+++ b/src/parser/jessiecode.js
@@ -315,7 +315,7 @@ define([
                             if (Type.exists(attributes)) {
                                 attr = attributes;
                             } else {
-                                attr = {name: (that.lhs[that.scope] !== 0 ? that.lhs[that.scope] : '')};
+                                attr = {name: (that.lhs[that.scope.id] !== 0 ? that.lhs[that.scope.id] : '')};
                             }
                             return that.board.create(vname, parameters, attr);
                         };
@@ -1163,7 +1163,7 @@ define([
                     break;
                 case 'op_assign':
                     v = this.getLHS(node.children[0]);
-                    this.lhs[this.scope.id] = v[1];
+                    this.lhs[this.scope.id] = v.what;
 
                     if (v.o.type && v.o.elementClass && v.o.methodMap && v.what === 'label') {
                         this._error('Left-hand side of assignment is read-only.');


### PR DESCRIPTION
It looks like the intention was that when you create an object without
any explicit attributes, like:

```
A = point(0,0):
```

the resulting point is given the name `A`.

The bit of the `op_assign` handler that store the name on the LHS was
broken - maybe the return value of `getLHS` changed since it was written?

I think it would be even more convenient if the LHS name was used even
if there are attributes given, but not the `name` or `id` attributes,
but for now this is a conservative fix to what the apparent intended
behaviour was.