### PR TITLE
escape backslashes in strings when dumping to JCAN

### DIFF
--- a/src/utils/dump.js
+++ b/src/utils/dump.js
@@ -304,7 +304,7 @@ define(['jxg', 'utils/type'], function (JXG, Type) {
                 }
                 return 'null';
             case 'string':
-                return '\'' + obj.replace(/(["'])/g, '\\$1') + '\'';
+                return '\'' + obj.replace(/\\/g,'\\\\').replace(/(["'])/g, '\\$1') + '\'';
             case 'number':
             case 'boolean':
                 return obj.toString();


### PR DESCRIPTION
The method `JXG.Dump.toJessie` calls `JXG.Dump.toJCAN` to render attribute objects. When rendering strings, it needs to escape backslashes. 

This affected a board containing LaTeX labels - the backslashes before LaTeX commands weren't escaped, so were lost when loading the dumped JessieCode.

This commit makes sure the backslashes are escaped.