### PR TITLE
Module "jsxgraph" support in index.d.ts

### DIFF
--- a/distrib/index.d.ts
+++ b/distrib/index.d.ts
@@ -14,9 +14,9 @@
 //
 
 /**
- * JXG namespace.
+ * JSXGraph in the namespace JXG.
  */
-declare module JXG {
+declare namespace JXG {
   /**
    *
    */
@@ -5265,4 +5265,11 @@ declare module JXG {
      */
     rungeKutta(butcher: unknown, x0: number[], I: number[], N: number, f: unknown): number[][];
   }
+}
+
+/**
+ * JSXGraph in the module "jsxgraph".
+ */
+declare module "jsxgraph" {
+  export = JXG;
 }


### PR DESCRIPTION
This change allows the index.d.ts file to support use cases in which the JSXGraph library is loaded in the global namespace as the property JXG, and when the library is loaded as a module with the name "jsxgraph".

e.g. As a namespace:

const board = JXG.JSXGraph.initBoard(...

e.g. As a module:

import { JSXGraph } from 'jsxgraph'

const board = JSXGraph.initBoard(...