### PR TITLE
Added Board.create function for inequality

### DIFF
--- a/distrib/index.d.ts
+++ b/distrib/index.d.ts
@@ -4028,6 +4028,13 @@ declare namespace JXG {
     create(elementType: 'image', parents: unknown[], attributes?: ImageAttributes): Image;
     /**
      *
+     * @param elementType 'inequality'
+     * @param parents
+     * @param attributes
+     */
+    create(elementType: 'inequality', parents: unknown[], attributes?: InequalityAttributes): Inequality;
+    /**
+     *
      * @param elementType 'input'
      * @param parents
      * @param attributes


### PR DESCRIPTION
Added an additionally function definition in the _index.d.ts_ file for the Board class to create an inequality element.
This will avoid typescript errors when calling this function within typescript environments.

* Fixes #425