### PR TITLE
Improve TypeScript definition for the `Ticks` class

### DIFF
--- a/distrib/index.d.ts
+++ b/distrib/index.d.ts
@@ -2939,8 +2939,61 @@ declare namespace JXG {
    */
   export class Ticks extends GeometryElement {
     constructor(line: Line, ticks: number | unknown[], attributes: TicksAttributes);
+
+    /**
+     * Equidistant ticks. Distance is defined by `ticksFunction`.
+     */
+    equidistant: boolean;
+
+    /**
+     * Array of fixed ticks.
+     */
+    fixedTicks: number[] | null;
+
+    /**
+     * To ensure the uniqueness of label ids this counter is used.
+     */
+    labelCounter: number;
+
+    /**
+     * Array where the labels are saved.
+     */
+    labels: Label[];
+
+    /**
+     * The line the ticks belong to.
+     */
+    line: Line;
+
+    /**
+     * Least distance between two ticks, measured in pixels.
+     */
+    minTicksDistance: number;
+
+    /**
+     * Stores the ticks coordinates as an array of length 3.
+     *
+     * The first two entries of the array are path coordinates in screen
+     * coordinates of the tick (arrays of length 2). The 3rd entry is true if
+     * the tick is a major tick, otherwise false.
+     *
+     * If the tick is outside of the canvas, the return array is empty.
+     */
+    ticks: Array<[[x1: number, x2: number], [y1: number, y2: number], boolean]>;
+
+    /**
+     * Distance between two major ticks in user coordinates
+     */
+    ticksDelta: number;
+
+    /**
+     * A function calculating ticks delta depending on the ticks number.
+     */
+    ticksFunction: () => number;
+
     setAttribute(attributes: TicksAttributes): this;
   }
+
   /**
    *
    */


### PR DESCRIPTION
This updates the `Ticks` class type definition to more comprehensively cover the available attributes and fields the class has.

I used the [`Ticks` doc webpage](https://jsxgraph.org/docs/symbols/JXG.Ticks.html#ticksDelta) as reference, and also the [`ticks.js` source file](https://github.com/jsxgraph/jsxgraph/blob/master/src/base/ticks.js).

---

**NOTE:** I intentionally left out `labelData` when updating the class definition. It seems like it's [always initialized to an empty array](https://github.com/jsxgraph/jsxgraph/blob/master/src/base/ticks.js#L158) and then never modified, but I might have missed something. Maybe it's a deprecated field?