### PR TITLE
Set `handler` parameter as optional for `off` function declaration

### DIFF
--- a/distrib/index.d.ts
+++ b/distrib/index.d.ts
@@ -583,7 +583,7 @@ declare namespace JXG {
      * @param handler
      * @returns Reference to the object.
      */
-    off(event: string, handler: (e: Event) => void): this;
+    off(event: string, handler?: (e: Event) => void): this;
 
     /**
      * Register a new event handler.


### PR DESCRIPTION
From what I saw in the code for unregistering an event listener in `event.js`, it seems like this `handler` parameter should be optional.