### PR TITLE
Fix missing directory in NPM package, missing dependency

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,3 +8,5 @@
 !distrib/*.ts
 !distrib/*.css
 !distrib/*/*.js
+# Allow all JavaScript files from the build folder
+!build/*.js

--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-{
+1{
   "name": "jsxgraph",
   "description": "Interactive geometry, plotting, visualization",
   "homepage": "https://jsxgraph.org",
@@ -40,6 +40,9 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/jsxgraph/jsxgraph.git"
+  },
+  "dependencies": {
+    "canvas": "^2.10.1",
   },
   "devDependencies": {
     "almond": "^0.3.3",


### PR DESCRIPTION
Hello! I'm currently working on a Clojurescript API around JSXGraph. I ran across two issues when trying to build my code with the `jsxgraph` 1.4.5 npm dependency:

1. canvas is not declared as a dependency. I was able to fix this by manually adding `canvas` to my `package.json`:

```
"canvas": "^2.10.1"
```

Is there a reason that the dependency is not explicitly declared?

2. the `build` directory is not making it into the `npm` package, triggering this error:

```
[:sicm-browser] Build failure:
failed to resolve: ../build/core.deps.js from /Users/sritchie/code/clj/sicmutils-clerk/node_modules/jsxgraph/distrib/jsxgraphcore.js
{:require-from #object[java.io.File 0x3ecd09a7 "/Users/sritchie/code/clj/sicmutils-clerk/node_modules/jsxgraph/distrib/jsxgraphcore.js"], :require "../build/core.deps.js"}
ExceptionInfo: failed to resolve: ../build/core.deps.js from /Users/sritchie/code/clj/sicmutils-clerk/node_modules/jsxgraph/distrib/jsxgraphcore.js
	shadow.build.npm/find-file (npm.clj:464)
	shadow.build.npm/find-file (npm.clj:405)
	shadow.build.npm/find-resource (npm.clj:741)
	shadow.build.npm/find-resource (npm.clj:734)
```

Adding that directory manually to `node_modules/jsxgraph` in my project fixes the error.

This PR fixes both of those issues, probably with too tight of a restriction on the canvas version you'd like to provide. Hopefully this report and patch are helpful!
