### PR TITLE
Add type for setClassicColors & touchProperty

### DIFF
--- a/distrib/index.d.ts
+++ b/distrib/index.d.ts
@@ -731,6 +731,11 @@ declare namespace JXG {
         white: string;
     };
 
+    /**
+     * Use the color scheme of JSXGraph up to version 1.3.2.
+     */
+    export type setClassicColors = () => void;
+
     export type Coordinate = number | string | NumberFunction | Point | Transformation;
 
     /**
@@ -5767,6 +5772,8 @@ declare namespace JXG {
          */
         percentile(arr: number[], percentile: number | number[]): number | number[];
     }
+
+    export type touchProperty = string;
 }
 
 /**


### PR DESCRIPTION
> setClassicColors :

Usage: [JxgContainer/gameOfLife/index.ts/#L90](https://github.com/Leslie-Wong-H/game_of_life/blob/78ae3808b7079e2e5820a380276b5b73c7ce739c/src/components/JxgContainer/gameOfLife/index.ts#L90)

> touchProperty:

Usage: [JxgContainer/gameOfLife/index.ts/#L188](https://github.com/Leslie-Wong-H/game_of_life/blob/master/src/components/JxgContainer/gameOfLife/index.ts#L188)
Origin: [Browser_event_and_coordinates](http://jsxgraph.org/wiki/index.php/Browser_event_and_coordinates)