### PR TITLE
Add Katex to TextOptions typescript types

### DIFF
--- a/distrib/index.d.ts
+++ b/distrib/index.d.ts
@@ -1265,6 +1265,10 @@ declare namespace JXG {
          *
          */
         useMathJax?: boolean;
+        /**
+         * Render the text through Katex.
+         */
+        useKatex?: boolean;
     }
 
     /**
@@ -5144,6 +5148,7 @@ declare namespace JXG {
         useASCIIMathML?: boolean;
         useCaja?: boolean;
         useMathJax?: boolean;
+        useKatex?: boolean;
         visible?: boolean;
         withLabel?: boolean;
     }

--- a/distrib/index.d.ts
+++ b/distrib/index.d.ts
@@ -1838,6 +1838,7 @@ declare namespace JXG {
         strokeColor?: string;
         strokeOpacity?: number;
         useMathJax?: boolean;
+        useKatex?: boolean;
         visible?: 'inherit' | boolean;
     }
 

--- a/distrib/index.d.ts
+++ b/distrib/index.d.ts
@@ -1265,10 +1265,6 @@ declare namespace JXG {
          *
          */
         useMathJax?: boolean;
-        /**
-         * Render the text through Katex.
-         */
-        useKatex?: boolean;
     }
 
     /**
@@ -1842,7 +1838,6 @@ declare namespace JXG {
         strokeColor?: string;
         strokeOpacity?: number;
         useMathJax?: boolean;
-        useKatex?: boolean;
         visible?: 'inherit' | boolean;
     }
 

--- a/src/options.js
+++ b/src/options.js
@@ -606,7 +606,7 @@ define([
                 needShift: true,
                 needTwoFingers: false
             },
-            browserPan: true,
+            browserPan: false,
 
             /**
              * Control the possibilities for dragging objects.


### PR DESCRIPTION
Currently the types defined in JSXGraph do not include useKatex. This means that if you're using Typescript then useKatex will throw and error and the application won't run without a well placed tsignore.

This pull request adds useKatex to TextOptions.