### PR TITLE
Fix error in coordselement event handler

### DIFF
--- a/src/base/coordselement.js
+++ b/src/base/coordselement.js
@@ -751,7 +751,7 @@ JXG.extend(
         updateRendererGeneric: function (rendererMethod) {
             //var wasReal;
 
-            if (!this.needsUpdate) {
+            if (!this.needsUpdate || !this.board.renderer) {
                 return this;
             }
 


### PR DESCRIPTION
During experimentation I was running into an error where, when I removed a board with

```
board.suspendUpdate()
JXG.JSXGraph.freeBoard(board)
```

I would see many errors like this:

```
module$node_modules$$mentatcollective$jsxgraph$src$base$coordselement.js:21 Uncaught TypeError: Cannot read properties of undefined (reading 'updateText')
    at _jxg.default.Text.updateRendererGeneric (module$node_modules$$mentatcollective$jsxgraph$src$base$coordselement.js:21:377)
    at _jxg.default.Text.updateRenderer (module$node_modules$$mentatcollective$jsxgraph$src$base$text.js:15:508)
    at eval (module$node_modules$$mentatcollective$jsxgraph$src$base$text.js:10:461)
```

larger screenshot, since I can't seem to copy out my full stacktrace...

<img width="722" alt="image" src="https://user-images.githubusercontent.com/69635/198706002-8b3368ad-fa91-4b36-81cf-efece8da234a.png">

I'm not sure that this is the right fix but it definitely removes the errors.
