### PR TITLE
Pass explicit reference to $jc$ in jessiecode.js

### DIFF
--- a/src/parser/jessiecode.js
+++ b/src/parser/jessiecode.js
@@ -678,16 +678,19 @@ JXG.extend(
                 this.replaceNames(node.children[1]);
 
                 /** @ignore */
-                fun = (function ($jc$) {
+                fun = (function (jc) {
                     var fun,
-                        str = "var f = " + $jc$.functionCodeJS(node) + "; f;";
+                        str =
+                            "var f = function($jc$) { return " +
+                            jc.functionCodeJS(node) +
+                            "}; f;";
 
                     try {
                         // yeah, eval is evil, but we don't have much choice here.
                         // the str is well defined and there is no user input in it that we didn't check before
 
                         /*jslint evil:true*/
-                        fun = eval(str);
+                        fun = eval(str)(jc);
                         /*jslint evil:false*/
 
                         scope.argtypes = [];
@@ -697,9 +700,7 @@ JXG.extend(
 
                         return fun;
                     } catch (e) {
-                        $jc$._warn(
-                            "error compiling function\n\n" + str + "\n\n" + e.toString()
-                        );
+                        jc._warn("error compiling function\n\n" + str + "\n\n" + e.toString());
                         return function () {};
                     }
                 })(this);


### PR DESCRIPTION
This PR modifies the Jessiecode `eval` call to explicitly pass the `$jc$` object in, instead of relying on Javascript's scoping and the variable name in the surrounding function.

The old style caused problems for me after running JSXGraph through the Google Closure compiler, which aggressively renames variables. The rename of `$jc$` caused my `"functiongraph"` examples to fail.