### PR TITLE
Solve ReferenceError crashes when running in NodeJS

### DIFF
--- a/src/base/board.js
+++ b/src/base/board.js
@@ -151,7 +151,7 @@ define([
         // this.document = attributes.document || document;
         if (Type.exists(attributes.document) && attributes.document !== false) {
             this.document = attributes.document;
-        } else if (document !== undefined && Type.isObject(document)) {
+        } else if (Env.isBrowser) {
             this.document = document;
         }
 

--- a/src/jsxgraph.js
+++ b/src/jsxgraph.js
@@ -481,7 +481,7 @@ define([
             attr = this._setAttributes(attributes);
 
             dimensions = Env.getDimensions(box, attr.document);
-            renderer = this.initRenderer(box, dimensions, attr.document);
+            renderer = this.initRenderer(box, dimensions, attr.document, attr.renderer);
             this._setARIA(box, attr);
 
             /* User default parameters, in parse* the values in the gxt files are submitted to board */

--- a/src/jsxgraph.js
+++ b/src/jsxgraph.js
@@ -227,13 +227,16 @@ define([
          * @private
          */
         _setARIA: function(container, attr) {
-            var doc = attr.document || document,
+            var doc = attr.document,
                 doc_glob,
                 node_jsx, newNode, parent,
                 id_label, id_description;
 
             if (typeof doc !== 'object') {
-                return;
+                if (!Env.isBrowser) {
+                    return;
+                }
+                doc = document;
             }
 
             node_jsx = doc.getElementById(container);


### PR DESCRIPTION
When trying to use JSXGraph in a NodeJS environment with the 'no' renderer, I experienced some crashes due to the `document` being referenced as a fallback. Without any libraries like jsdom, the `document` variable doesn't exist and causes a ReferenceError in cases like `document !== undefined`. 

The environment module already had an `isBrowser` flag that properly checks for this problem, so the fix was straightforward. I tried to write a test case to test for this problem, but so far have been unsuccessful. If I understand correctly, karma + jasmine requires a (headless) browser to run, making it impossible to test for this problem using this suite. I'm not familiar enough with other testing options used, but if there's a way to build a test without a browser being initialized I'll gladly write some unit tests.