### PR TITLE
Fixes for JSXGraph in ShadowDOM

### DIFF
--- a/src/renderer/abstract.js
+++ b/src/renderer/abstract.js
@@ -1998,12 +1998,13 @@ define([
          * Wrapper for getElementById for maybe other renderers which elements are not directly accessible by DOM
          * methods like document.getElementById().
          * @param {String} id Unique identifier for element.
-         * @returns {Object} Reference to a JavaScript object. In case of SVG/VMLRenderer it's a reference to a SVG/VML
-         * node.
+         * @returns {Object} Reference to a JavaScript object. In case of SVG/VMLRenderer it's a reference to a SVG/VML node.
          */
         getElementById: function (id) {
             if (Type.exists(this.container)) {
-                return this.container.ownerDocument.getElementById(this.container.id + '_' + id);
+                // Use querySelector over getElementById for compatibility with both 'regular' document
+                // and ShadowDOM fragments.
+                return this.container.querySelector('#' + this.container.id + '_' + id);
             }
             return '';
         },

--- a/src/utils/type.js
+++ b/src/utils/type.js
@@ -136,6 +136,17 @@ define([
         },
 
         /**
+         * Tests if the input variable is a DOM Document or DocumentFragment node
+         * @param v A variable of any type
+         */
+        isDocumentOrFragment: function (v) {
+            return this.isObject(v) && (
+                v.nodeType === 9 || // Node.DOCUMENT_NODE  
+                v.nodeType === 11   // Node.DOCUMENT_FRAGMENT_NODE
+            );
+        },
+
+        /**
          * Checks if a given variable is a reference of a JSXGraph Point element.
          * @param v A variable of any type.
          * @returns {Boolean} True, if v is of type JXG.Point.
@@ -1017,14 +1028,14 @@ define([
                     e2 = (toLower) ? e.toLowerCase(): e;
 
                     o = special[e];
-                    if (this.isObject(o) && o !== null && !this.exists(o.board)) {
+                    if (this.isObject(o) && o !== null && !this.isDocumentOrFragment(o) && !this.exists(o.board)) {
                         if (attr[e2] === undefined || attr[e2] === null || !this.isObject(attr[e2])) {
                             // The last test handles the case:
                             //   attr.draft = false;
                             //   special.draft = { strokewidth: 4}
                             attr[e2] = {};
                         }
-                        this.mergeAttr(attr[e2], o, toLower)
+                        this.mergeAttr(attr[e2], o, toLower);
                     } else {
                         // Flat copy
                         // This is also used in the cases


### PR DESCRIPTION
Two fixes:
- The new implementation to merge attribute objects, attempts to deepcopy the `document` object when provided in the board initialization attributes. It should, however, be considered as a black box value and get flat copied. 
- The `getElementById` wrapper function in the renderer objects uses the `getElementById` function of the wrong, top-level document root. When the `container` field is inside a shadow DOM, the element will not be found. This is demonstrated in https://jsfiddle.net/jwmhoztb/3/ where removing the point via the button results in the button being removed from the construction logic, but remains visible in the SVG because it's DOM element isn't found. Proposed change uses the `querySelector` method that can be called from any document Node.