### PR TITLE
Feature: Apply tickendings constraint to 'full height' ticks

### DIFF
--- a/src/base/ticks.js
+++ b/src/base/ticks.js
@@ -935,7 +935,10 @@ define([
                 style,
                 x = [-2000000, -2000000],
                 y = [-2000000, -2000000],
-                i, r, r_max, bb, full, delta;
+                i, r, r_max, bb, full, delta,
+                // Used for infinite ticks
+                te0, te1, // Tick ending visProps
+                dists; // 'signed' distances of intersections to the parent line
 
             c = coords.scrCoords;
             if (major) {
@@ -980,10 +983,68 @@ define([
                 // line style
                 if (style === 'infinite') {
                     intersection = Geometry.meetLineBoard(lineStdForm, this.board);
-                    x[0] = intersection[0].scrCoords[1];
-                    x[1] = intersection[1].scrCoords[1];
-                    y[0] = intersection[0].scrCoords[2];
-                    y[1] = intersection[1].scrCoords[2];
+
+                    te0 = Type.evaluate(this.visProp.tickendings[0]) > 0;
+                    te1 = Type.evaluate(this.visProp.tickendings[1]) > 0;
+                    
+                    if (te0 && te1) {
+                        x[0] = intersection[0].scrCoords[1];
+                        x[1] = intersection[1].scrCoords[1];
+                        y[0] = intersection[0].scrCoords[2];
+                        y[1] = intersection[1].scrCoords[2];
+                    } else {
+                        // Assuming the usrCoords of both intersections are normalized, a 'signed distance'
+                        // with respect to the parent line is computed for the intersections. The sign is
+                        // used to conclude whether the point is either at the left or right side of the 
+                        // line. The magnitude can be used to compare the points and determine which point
+                        // is closest to the line.
+                        dists = [
+                            Mat.innerProduct(
+                                intersection[0].usrCoords.slice(1, 3),
+                                this.line.stdform.slice(1, 3) 
+                            ) + this.line.stdform[0],
+                            Mat.innerProduct(
+                                intersection[1].usrCoords.slice(1, 3),
+                                this.line.stdform.slice(1, 3)
+                            ) + this.line.stdform[0],
+                        ];
+                        
+                        // Reverse intersection array order if first intersection is not the leftmost one.
+                        if (dists[0] < dists[1]) {
+                            intersection.reverse();
+                            dists.reverse();
+                        }
+
+                        if (te0) { // Left-infinite tick
+                            if (dists[0] < 0) { // intersections at the wrong side of line
+                                return [];
+                            } else if (dists[1] < 0) { // 'default' case, tick drawn from line to board bounds
+                                x[0] = intersection[0].scrCoords[1];
+                                y[0] = intersection[0].scrCoords[2];
+                                x[1] = c[1];
+                                y[1] = c[2];
+                            } else { // tick visible, but coords of tick on line are outside the visible area
+                                x[0] = intersection[0].scrCoords[1];
+                                y[0] = intersection[0].scrCoords[2];
+                                x[1] = intersection[1].scrCoords[1];
+                                y[1] = intersection[1].scrCoords[2];
+                            } 
+                        } else if (te1) { // Right-infinite tick
+                            if (dists[1] > 0) { // intersections at the wrong side of line
+                                return [];
+                            } else if (dists[0] > 0) { // 'default' case, tick drawn from line to board bounds
+                                x[0] = c[1];
+                                y[0] = c[2];
+                                x[1] = intersection[1].scrCoords[1];
+                                y[1] = intersection[1].scrCoords[2];
+                            } else { // tick visible, but coords of tick on line are outside the visible area
+                                x[0] = intersection[0].scrCoords[1];
+                                y[0] = intersection[0].scrCoords[2];
+                                x[1] = intersection[1].scrCoords[1];
+                                y[1] = intersection[1].scrCoords[2];
+                            }
+                        }
+                    }
                 } else {
                     if (Type.evaluate(this.visProp.face) === '>') {
                         alpha = Math.PI/4;

--- a/src/options.js
+++ b/src/options.js
@@ -1886,7 +1886,7 @@ define([
             majorHeight: 10,
 
             /**
-             * Decides in which direction finite ticks are visible. Possible values are either the constants
+             * Decides in which direction ticks are visible. Possible values are either the constants
              * 0=false or 1=true or a function returning 0 or 1.
              *
              * In case of [0,1] the tick is only visible to the right of the line. In case of


### PR DESCRIPTION
The `tickendings` property is ignored when using 'full height' ticks (major- or minorheight < 0). Having unbounded ticks break off at the line does serve some purposes (for example: creating a grid for the first quadrant only).