### PR TITLE
updateContainerDims: avoid NaN when containerObj is not attached to the page

### DIFF
--- a/src/base/board.js
+++ b/src/base/board.js
@@ -3391,7 +3391,8 @@ define([
          */
         updateContainerDims: function() {
             var w, h,
-                bb, css;
+                bb, css,
+                width_adjustment, height_adjustment;
 
             // Get size of the board's container div
             bb = this.containerObj.getBoundingClientRect();
@@ -3401,8 +3402,14 @@ define([
             // Subtract the border size
             if (window && window.getComputedStyle) {
                 css = window.getComputedStyle(this.containerObj, null);
-                w -= parseFloat(css.getPropertyValue('border-left-width')) + parseFloat(css.getPropertyValue('border-right-width'));
-                h -= parseFloat(css.getPropertyValue('border-top-width'))  + parseFloat(css.getPropertyValue('border-bottom-width'));
+                width_adjustment = parseFloat(css.getPropertyValue('border-left-width')) + parseFloat(css.getPropertyValue('border-right-width'));
+                if(!isNaN(width_adjustment)) {
+                    w -= width_adjustment;
+                }
+                height_adjustment = parseFloat(css.getPropertyValue('border-top-width'))  + parseFloat(css.getPropertyValue('border-bottom-width'));
+                if(!isNaN(height_adjustment)) {
+                    h -= height_adjustment;
+                }
             }
 
             // If div is invisible - do nothing


### PR DESCRIPTION
When the board's container element is not attached to the page, its computed style is empty.

This commit checks for this, and avoids adding the width/height adjustment for the element's border if they resolve to NaN.

fixes #484