### PR TITLE
Add webpack module example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ trunk
 .c9revisions
 distrib/jsxgraphcore.js*
 distrib/jsxgraphsrc.js*
+distrib/jsxgraphcore.mjs*
+distrib/jsxgraphsrc.mjs*
 build/bin/*
 src/require.js
 node_modules

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -41,8 +41,8 @@ const config_es5 = {
         //    import JXG from "...jsxgraphcore"
         library: {
             name: libraryName,
-            type: 'var',
-            export: 'default'
+            type: "var",
+            export: "default"
         },
 
         // Unnamed AMD define
@@ -53,10 +53,10 @@ const config_es5 = {
 
         // Just comments
         auxiliaryComment: {
-            root: 'Root (browser)',
-            commonjs: 'CommonJS',
-            commonjs2: 'CommonJS2 (nodejs)',
-            amd: 'AMD'
+            root: "Root (browser)",
+            commonjs: "CommonJS",
+            commonjs2: "CommonJS2 (nodejs)",
+            amd: "AMD"
         }
     },
     target: ["web", "es5"],
@@ -100,9 +100,9 @@ const config_es5 = {
         // AMD does not need canvas, so would root.
         // commonjs2 needs the canvas plug-in
         canvas: {
-            commonjs: 'canvas',
-            commonjs2: 'canvas',
-            root: 'canvas'
+            commonjs: "canvas",
+            commonjs2: "canvas",
+            root: "canvas"
         }
     },
     optimization: {
@@ -115,28 +115,31 @@ const config_es5 = {
     }
 };
 
-const config_es6 = {
+const module_config = {
     ...baseConfig,
     devtool: "source-map",
     entry: {
-        jsxgraphsrc_es6: [PATHS.entryPoint],
-        jsxgraphcore_es6: [PATHS.entryPoint]
+        jsxgraphsrc: [PATHS.entryPoint],
+        jsxgraphcore: [PATHS.entryPoint]
+    },
+    experiments: {
+        outputModule: true
     },
     output: {
         path: PATHS.bundles,
-        filename: "[name].js",
+        filename: "[name].mjs",
+        library: { type: "module" }
     },
-    target: ["web"],
 
-    externals: 'canvas',
+    // externals: "canvas",
     optimization: {
         minimize: true,
         minimizer: [
             new TerserPlugin({
-                test: /core_es6\.js$/
+                test: /core\.mjs$/
             })
         ]
     }
 };
 
-module.exports = [config_es5, config_es6];
+module.exports = [config_es5, module_config];

--- a/examples/npm.html
+++ b/examples/npm.html
@@ -1,0 +1,13 @@
+<div id="jxgbox" class="jxgbox" style="width: 600px; height: 600px"></div>
+<script type="module">
+    import JXG from "../distrib/jsxgraphsrc.mjs";
+
+    const board = JXG.JSXGraph.initBoard("jxgbox", {
+        boundingbox: [-5, 5, 5, -5],
+        axis: true
+    });
+
+    let relation = board.jc.snippet("ln(x)", true, "x", false);
+    let curve = board.create("functiongraph", [relation]);
+    let integral = board.create("integral", [[2, 4], curve]);
+</script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "eslint": "^8.4.1",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.2.1",
+        "http-server": "^14.1.1",
         "jasmine-core": "^3.10.1",
         "jsdoc2": "^2.4.0",
         "jshint": "^2.13.1",
@@ -632,6 +633,15 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -645,6 +655,24 @@
       "engines": {
         "node": "^4.5.0 || >= 5.9"
       }
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/basic-auth/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -1048,6 +1076,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -1949,6 +1986,27 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/htmlparser2": {
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.8.3.tgz",
@@ -1999,6 +2057,45 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-server/node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/https-proxy-agent": {
@@ -2849,6 +2946,15 @@
         "wrappy": "1"
       }
     },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.1",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
@@ -3071,6 +3177,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/portfinder": {
+      "version": "1.0.32",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.32.tgz",
+      "integrity": "sha512-on2ZJVVDXRADWE6jnQaX0ioEylzgBpQk8r55NE4wjXW1ZxO+BgDlY6DXwj20i0V8eB4SenDQ00WEaxfiIQPcxg==",
+      "dev": true,
+      "dependencies": {
+        "async": "^2.6.4",
+        "debug": "^3.2.7",
+        "mkdirp": "^0.5.6"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/portfinder/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
       }
     },
     "node_modules/prelude-ls": {
@@ -3406,6 +3535,12 @@
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
       }
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "7.3.8",
@@ -3854,6 +3989,18 @@
         "node": "*"
       }
     },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -3906,6 +4053,12 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -4102,6 +4255,30 @@
       "dev": true,
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "eslint": "^8.4.1",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.2.1",
+    "http-server": "^14.1.1",
     "jasmine-core": "^3.10.1",
     "jsdoc2": "^2.4.0",
     "jshint": "^2.13.1",
@@ -82,6 +83,7 @@
     "eslint": "make eslint",
     "check-format": "prettier --check src test extensions",
     "format": "prettier --write src test extensions",
+    "serve": "http-server -c-1",
     "test": "make test"
   }
 }


### PR DESCRIPTION
Digging around, it looks like getting webpack to export a file that you can import as a module is still an experimental feature: https://webpack.js.org/configuration/output/#outputmodule

This PR makes it work though!

To get around CORS issues I.ve added the http-server dev dependency. Run

```
npm run buildCore && npm run serve
```

And visit http://localhost:8080/examples/npm.html.

I did have to comment out  `externals: "canvas"`

Or I would see

```
Uncaught TypeError: Failed to resolve module specifier "canvas". Relative references must start with either "/", "./", or "../".
```

Hopefully this is helpful!