### PR TITLE
Update *3D docs

### DIFF
--- a/src/3d/curve3d.js
+++ b/src/3d/curve3d.js
@@ -34,7 +34,7 @@ import Type from "../utils/type";
 
 /**
  * Constructor for 3D curves.
- * @class Creates a new 3D curve object. Do not use this constructor to create a 3D curve. Use {@link JXG.Board#create} with type {@link Curve3D} instead.
+ * @class Creates a new 3D curve object. Do not use this constructor to create a 3D curve. Use {@link JXG.View3D#create} with type {@link Curve3D} instead.
  *
  * @augments JXG.GeometryElement3D
  * @augments JXG.GeometryElement

--- a/src/3d/linspace3d.js
+++ b/src/3d/linspace3d.js
@@ -44,7 +44,7 @@ import Geometry from "../math/geometry";
 
 /**
  * Constructor for 3D lines.
- * @class Creates a new 3D line object. Do not use this constructor to create a 3D line. Use {@link JXG.Board#create} with type {@link Line3D} instead.
+ * @class Creates a new 3D line object. Do not use this constructor to create a 3D line. Use {@link JXG.View3D#create} with type {@link Line3D} instead.
  *
  * @augments JXG.GeometryElement3D
  * @augments JXG.GeometryElement

--- a/src/3d/point3d.js
+++ b/src/3d/point3d.js
@@ -37,7 +37,7 @@ import Type from "../utils/type";
 
 /**
  * A 3D point is the basic geometric element.
- * @class Creates a new 3D point object. Do not use this constructor to create a 3D point. Use {@link JXG.Board#create} with
+ * @class Creates a new 3D point object. Do not use this constructor to create a 3D point. Use {@link JXG.View3D#create} with
  * type {@link Point3D} instead.
  * @augments JXG.GeometryElement3D
  * @augments JXG.GeometryElement

--- a/src/3d/surface3d.js
+++ b/src/3d/surface3d.js
@@ -34,7 +34,7 @@ import Type from "../utils/type";
 
 /**
  * Constructor for 3D surfaces.
- * @class Creates a new 3D surface object. Do not use this constructor to create a 3D surface. Use {@link JXG.Board#create} with type {@link Surface3D} instead.
+ * @class Creates a new 3D surface object. Do not use this constructor to create a 3D surface. Use {@link JXG.View3D#create} with type {@link Surface3D} instead.
  *
  * @augments JXG.GeometryElement3D
  * @augments JXG.GeometryElement


### PR DESCRIPTION
@alfredwassermann , correct me if I'm wrong, but I THINK the only way to create these 3d elements is to do so on an actual view3d. Is that right? If so, then I think this change is necessary.