### PR TITLE
fix some typos and example added. See #523

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5614,6 +5614,7 @@ declare namespace JXG {
         useCaja?: boolean;
         useMathJax?: boolean;
         useKatex?: boolean;
+        katexMacros: Object;
         visible?: boolean;
         withLabel?: boolean;
     }

--- a/src/options.js
+++ b/src/options.js
@@ -6239,9 +6239,19 @@ JXG.Options = {
          * 
          * @name katexMacros
          * @memberOf Text.prototype
-         * @default {}}
+         * @default {}
          * @type Object
          * 
+         * @example
+         * // to globally apply macros to all text elements use:
+         * JXG.Options.text.katexMacros = {'\\jxg': 'JSXGraph is awesome'};
+         *
+         * const board = JXG.JSXGraph.initBoard('jxgbox', {
+         *     boundingbox: [-2, 5, 8, -5], axis:true
+         * });
+         *
+         * // This macro only get applied to the p ('text') element
+         * var p = board.create('text', [1, 0, '\\jsg \\sR '], { katexMacros: {'\\sR':'\\mathbb{R}'} });
          */
         katexMacros: {},
 

--- a/src/renderer/abstract.js
+++ b/src/renderer/abstract.js
@@ -1240,7 +1240,7 @@ JXG.extend(
                             try {
                                 /* eslint-disable no-undef */
                                 katex.render(content, el.rendNode, {
-                                    macros: Type.evaluate(el.visProp.katexMacros),
+                                    macros: Type.evaluate(el.visProp.katexmacros),
                                     throwOnError: false
                                 });
                                 /* eslint-enable no-undef */

--- a/update_cdnjs/index.d.ts
+++ b/update_cdnjs/index.d.ts
@@ -5614,6 +5614,7 @@ declare namespace JXG {
         useCaja?: boolean;
         useMathJax?: boolean;
         useKatex?: boolean;
+        katexMacros: Object;
         visible?: boolean;
         withLabel?: boolean;
     }


### PR DESCRIPTION
Hi, I made a few small corrections and now it works 😀.

This add support for Katex macros for text elements.