### PR TITLE
Make touchpoint offset dependent on point visibility

### DIFF
--- a/src/options.js
+++ b/src/options.js
@@ -4421,8 +4421,8 @@ JXG.Options = {
         snapSizeY: 1,
 
         /**
-         * If set to true and {@link Line#firstArrow} is set to true, the arrow head will just touch
-         * the circle line of the start point of the line.
+         * If set to true, {@link Line#firstArrow} is set to true and the point is visible, 
+         * the arrow head will just touch the circle line of the start point of the line.
          *
          * @see Line#firstArrow
          * @type Boolean
@@ -4432,8 +4432,8 @@ JXG.Options = {
         touchFirstPoint: false,
 
         /**
-         * If set to true and {@link Line#lastArrow} is set to true, the arrow head will just touch
-         * the circle line of the start point of the line.
+         * If set to true, {@link Line#lastArrow} is set to true and the point is visible, 
+         * the arrow head will just touch the circle line of the start point of the line.
          * @see Line#firstArrow
          * @type Boolean
          * @name Line#touchLastPoint

--- a/src/renderer/abstract.js
+++ b/src/renderer/abstract.js
@@ -823,14 +823,14 @@ JXG.extend(
                     Type.evaluate(el.point2.visProp.strokewidth);
 
                 // Handle touchlastpoint /touchfirstpoint
-                if (a.evFirst && Type.evaluate(el.visProp.touchfirstpoint)) {
+                if (a.evFirst && Type.evaluate(el.visProp.touchfirstpoint) && Type.evaluate(el.point1.visProp.visible)) {
                     d = c1.distance(Const.COORDS_BY_SCREEN, c2);
                     //if (d > s) {
                     d1x = ((c2.scrCoords[1] - c1.scrCoords[1]) * s1) / d;
                     d1y = ((c2.scrCoords[2] - c1.scrCoords[2]) * s1) / d;
                     //}
                 }
-                if (a.evLast && Type.evaluate(el.visProp.touchlastpoint)) {
+                if (a.evLast && Type.evaluate(el.visProp.touchlastpoint) && Type.evaluate(el.point2.visProp.visible)) {
                     d = c1.distance(Const.COORDS_BY_SCREEN, c2);
                     //if (d > s) {
                     d2x = ((c2.scrCoords[1] - c1.scrCoords[1]) * s2) / d;


### PR DESCRIPTION
When working with vectors (line elements with 'straightLast': false and 'lastArrow' configured) and the 'touchLastPoint' property, I noticed that making the last point invisible creates a visual discrepancy because the arrow is still pointing at the outer edge of where the point would be.

I think it would be nice if the 'touchLastPoint' only creates an offset if the point it is compensating for is actually visible, but I'd like to hear your opinion as well.

To demonstrate the behavior I created a small fiddle
https://jsfiddle.net/dv6pybku/2/