### PR TITLE
Sliders can take a list of values to snap to when within a given distance

### DIFF
--- a/src/element/slider.js
+++ b/src/element/slider.js
@@ -179,12 +179,15 @@ define([
     JXG.createSlider = function (board, parents, attributes) {
         var pos0, pos1, smin, start, smax, sdiff,
             p1, p2, l1, ticks, ti, startx, starty, p3, l2, t,
-            withText, withTicks, snapWidth, sw, s, attr, digits;
+            withText, withTicks, snapWidth, snapValues, 
+            snapValueDistance, sw, s, attr, digits;
 
         attr = Type.copyAttributes(attributes, board.options, 'slider');
         withTicks = attr.withticks;
         withText = attr.withlabel;
         snapWidth = attr.snapwidth;
+        snapValues = attr.snapvalues;
+        snapValueDistance = attr.snapvaluedistance;
 
         // start point
         attr = Type.copyAttributes(attributes, board.options, 'slider', 'point1');
@@ -221,7 +224,7 @@ define([
         attr.withLabel = false;
         // gliders set snapwidth=-1 by default (i.e. deactivate them)
         p3 = board.create('glider', [startx, starty, l1], attr);
-        p3.setAttribute({snapwidth: snapWidth});
+        p3.setAttribute({snapwidth: snapWidth, snapvalues: snapValues, snapvaluedistance: snapValueDistance});
 
         // Segment from start point to glider point: highline
         attr = Type.copyAttributes(attributes, board.options, 'slider', 'highline');
@@ -236,7 +239,20 @@ define([
          */
         p3.Value = function () {
             var sdiff = this._smax - this._smin,
-                ev_sw = Type.evaluate(this.visProp.snapwidth);
+                ev_sw = Type.evaluate(this.visProp.snapwidth),
+                snappedTo = p3.findClosestSnapValue(this.position),
+                snapValues, i, v;
+
+            snapValues = Type.evaluate(this.visProp.snapvalues);
+            if (Type.isArray(snapValues)) {
+                for (i=0; i < snapValues.length; i++) {
+                    v = (snapValues[i] - this._smin) / (this._smax - this._smin);
+                    console.log(`${this.position} - ${snapValues[i]} = ${this.position - v}`);
+                    if(this.position == v) {
+                        return snapValues[i];
+                    }
+                }
+            }
 
             return ev_sw === -1 ?
                         this.position * sdiff + this._smin :

--- a/src/options.js
+++ b/src/options.js
@@ -4900,6 +4900,28 @@ define([
             snapWidth: -1,      // -1 = deactivated
 
             /**
+             * List of values to snap to. If the glider is within snapValueDistance of one of these points, 
+             * then the glider snaps to that point.
+             *
+             * @memberOf Slider.prototype
+             * @name snapValues
+             * @type Array
+             * @default empty
+             */
+            snapValues: [],
+
+            /** 
+             * If the difference between the slider value and one of the elements of snapValues is less
+             * than this number, the slider will snap to that value.
+             *
+             * @memberOf Slider.prototype
+             * @name snapValueDistance
+             * @type Number
+             * @default 0.0
+             */
+            snapValueDistance: 0.0,
+
+            /**
              * The precision of the slider value displayed in the optional text.
              * Replaced by the attribute "digits".
              *


### PR DESCRIPTION
Fixes #577.

Sliders have two new attributes: `snapValues` and `snapValueDistance`. When the glider is within `snapValueDistance` of an entry in `snapValues`, it snaps to that value.
This takes precedence over `snapWidth`: that is only applied if the glider has not snapped to one of the `snapValues`.