### PR TITLE
Sliders can take a list of values to snap to

### DIFF
--- a/src/base/coordselement.js
+++ b/src/base/coordselement.js
@@ -245,6 +245,7 @@ JXG.extend(
                 newCoords, newPos,
                 doRound = false,
                 ev_sw,
+                snappedTo, snapValues,
                 slide = this.slideObject,
                 res, cu,
                 slides = [],
@@ -373,20 +374,28 @@ JXG.extend(
                     }
                 }
 
-                // Snap the glider point of the slider into its appropiate position
-                // First, recalculate the new value of this.position
-                // Second, call update(fromParent==true) to make the positioning snappier.
-                ev_sw = Type.evaluate(this.visProp.snapwidth);
-                if (
-                    Type.evaluate(ev_sw) > 0.0 &&
-                    Math.abs(this._smax - this._smin) >= Mat.eps
-                ) {
-                    newPos = Math.max(Math.min(newPos, 1), 0);
-
-                    v = newPos * (this._smax - this._smin) + this._smin;
-                    v = Math.round(v / ev_sw) * ev_sw;
-                    newPos = (v - this._smin) / (this._smax - this._smin);
+                // Snap the glider to snap values.
+                snappedTo = this.findClosestSnapValue(newPos);
+                if(snappedTo !== null) {
+                    snapValues = Type.evaluate(this.visProp.snapvalues);
+                    newPos = (snapValues[snappedTo] - this._smin) / (this._smax - this._smin);
                     this.update(true);
+                } else {
+                    // Snap the glider point of the slider into its appropiate position
+                    // First, recalculate the new value of this.position
+                    // Second, call update(fromParent==true) to make the positioning snappier.
+                    ev_sw = Type.evaluate(this.visProp.snapwidth);
+                    if (
+                        Type.evaluate(ev_sw) > 0.0 &&
+                        Math.abs(this._smax - this._smin) >= Mat.eps
+                    ) {
+                        newPos = Math.max(Math.min(newPos, 1), 0);
+
+                        v = newPos * (this._smax - this._smin) + this._smin;
+                        v = Math.round(v / ev_sw) * ev_sw;
+                        newPos = (v - this._smin) / (this._smax - this._smin);
+                        this.update(true);
+                    }
                 }
 
                 p1c = slide.point1.coords;
@@ -531,6 +540,35 @@ JXG.extend(
 
             this.coords.setCoordinates(Const.COORDS_BY_USER, newCoords.usrCoords, doRound);
             this.position = newPos;
+        },
+
+        /** 
+         * Find the closest entry in snapValues that is within snapValueDistance of pos.
+         *
+         * @returns {Number} Index of the value to snap to, or null.
+         */
+        findClosestSnapValue: function(pos) {
+            var i, d,
+                snapValues, snapValueDistance, 
+                snappedTo = null;
+
+            // Snap the glider to snap values.
+            snapValues = Type.evaluate(this.visProp.snapvalues);
+            snapValueDistance = Type.evaluate(this.visProp.snapvaluedistance);
+
+            if (Type.isArray(snapValues) &&
+                Math.abs(this._smax - this._smin) >= Mat.eps &&
+                snapValueDistance > 0.0) {
+                for (i = 0; i < snapValues.length; i++) {
+                    d = Math.abs(pos * (this._smax - this._smin) + this._smin - snapValues[i]);
+                    if (d < snapValueDistance) {
+                        snapValueDistance = d;
+                        snappedTo = i;
+                    }
+                }
+            }
+
+            return snappedTo;
         },
 
         /**

--- a/src/element/slider.js
+++ b/src/element/slider.js
@@ -168,6 +168,7 @@ JXG.createSlider = function (board, parents, attributes) {
         ticks, ti, t,
         startx, starty,
         withText, withTicks,
+        snapValues, snapValueDistance,
         snapWidth, sw, s,
         attr;
 
@@ -175,6 +176,8 @@ JXG.createSlider = function (board, parents, attributes) {
     withTicks = attr.withticks;
     withText = attr.withlabel;
     snapWidth = attr.snapwidth;
+    snapValues = attr.snapvalues;
+    snapValueDistance = attr.snapvaluedistance;
 
     // start point
     attr = Type.copyAttributes(attributes, board.options, "slider", "point1");
@@ -211,7 +214,7 @@ JXG.createSlider = function (board, parents, attributes) {
     attr.withLabel = false;
     // gliders set snapwidth=-1 by default (i.e. deactivate them)
     p3 = board.create("glider", [startx, starty, l1], attr);
-    p3.setAttribute({ snapwidth: snapWidth });
+    p3.setAttribute({ snapwidth: snapWidth, snapvalues: snapValues, snapvaluedistance: snapValueDistance });
 
     // Segment from start point to glider point: highline
     attr = Type.copyAttributes(attributes, board.options, "slider", "highline");
@@ -226,7 +229,18 @@ JXG.createSlider = function (board, parents, attributes) {
      */
     p3.Value = function () {
         var sdiff = this._smax - this._smin,
-            ev_sw = Type.evaluate(this.visProp.snapwidth);
+            ev_sw = Type.evaluate(this.visProp.snapwidth),
+            snapValues, i, v;
+
+        snapValues = Type.evaluate(this.visProp.snapvalues);
+        if (Type.isArray(snapValues)) {
+            for (i=0; i < snapValues.length; i++) {
+                v = (snapValues[i] - this._smin) / (this._smax - this._smin);
+                if(this.position === v) {
+                    return snapValues[i];
+                }
+            }
+        }
 
         return ev_sw === -1
             ? this.position * sdiff + this._smin

--- a/src/options.js
+++ b/src/options.js
@@ -6124,6 +6124,29 @@ JXG.Options = {
         snapWidth: -1,      // -1 = deactivated
 
         /**
+         * List of values to snap to. If the glider is within snapValueDistance of one of these points, 
+         * then the glider snaps to that point.
+         *
+         * @memberOf Slider.prototype
+         * @name snapValues
+         * @type Array
+         * @default empty
+         */
+        snapValues: [],
+
+        /**
+         * If the difference between the slider value and one of the elements of snapValues is less
+         * than this number, the slider will snap to that value.
+         *
+         * @memberOf Slider.prototype
+         * @name snapValueDistance
+         * @type Number
+         * @default 0.0
+         */
+        snapValueDistance: 0.0,
+
+
+        /**
          * The precision of the slider value displayed in the optional text.
          * Replaced by the attribute "digits".
          *


### PR DESCRIPTION
Fixes #577.

Sliders have two new attributes: `snapValues` and `snapValueDistance`. When the glider is within `snapValueDistance` of an entry in `snapValues`, it snaps to that value.
This takes precedence over `snapWidth`: that is only applied if the glider has not snapped to one of the `snapValues`.