### PR TITLE
Add comment on the function returned by regressionPolynomial

### DIFF
--- a/src/math/numerics.js
+++ b/src/math/numerics.js
@@ -2522,6 +2522,7 @@ Mat.Numerics = {
      * @param {Array} dataY Array containing the y-coordinates of the data set,
      * @returns {function} A function of one parameter which returns the value of the regression polynomial of the given degree.
      * It possesses the method getTerm() which returns the string containing the function term of the polynomial.
+     * The function returned will throw an exception, if the data set is malformed. 
      * @memberof JXG.Math.Numerics
      */
     regressionPolynomial: function (degree, dataX, dataY) {


### PR DESCRIPTION
An example of a malformed dataset:  there is no regression polynomial of degree 1 for the points (0,1) and (0,2). 