### PR TITLE
add link to slider in it's sub-elements

### DIFF
--- a/src/element/slider.js
+++ b/src/element/slider.js
@@ -478,11 +478,16 @@ JXG.createSlider = function (board, parents, attributes) {
     };
 
     p1.dump = false;
+    p1.slider = p3;
     p2.dump = false;
+    p2.slider = p3;
     l1.dump = false;
+    l1.slider = p3;
     l2.dump = false;
+    l2.slider = p3;
     if (withText) {
         t.dump = false;
+        t.slider = p3;
     }
 
     p3.elType = "slider";


### PR DESCRIPTION
The sub-elements of sliders are very specific and are normally only used for the slider. It would be good if the slider itself (=glider point) could be accessed directly from the sub-elements. This would also make it possible to recognize whether an element (e.g. a line) is a subelement of a slider (if the attribute slider is set).