### PR TITLE
tiny correction to indes.t.ds for typescript

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3354,7 +3354,7 @@ declare namespace JXG {
         point1?: PointAttributes;
         point2?: PointAttributes;
         digits?: number;
-        ticks?: TicksAttributes;
+        ticks?: TicksOptions;
         withLabel?: boolean;
         withTicks?: boolean;
     }


### PR DESCRIPTION
Thank you for creating this amazing tool !!


I have corrected *TapemeasureAttributes* to use *TicksOptions* instead of *TicksAttributes* in the *index.d.ts* file.

I am NOT an expert in JSXGraph, just trying to create some simple constructions with TypeScript.   An error prevents me from moving forward.  I think this is how to fix it.

The Typescript index.d.tx contains two very similar interfaces: *TicksOptions* and *TicksAttributes*.   TicksOptions appears to be more complete.   Mostly they don't conflict, except at line 3357 in *index.d.ts*.    

Note: there are TWO copies of *index.d.ts* in your repository.  I have only corrected the one in the SRC file.  The other looks to be part of your workflow to update the CDN.

I suspect the other references to *TicksOptions* should be replaced with *TicksAttributes* too.


Here's what VSCode says...

![error1](https://github.com/jsxgraph/jsxgraph/assets/11073753/3a87db35-24d8-4e32-ad87-deebfb58c55f)

Here's what running TypeScript says...

![error2](https://github.com/jsxgraph/jsxgraph/assets/11073753/a3629677-4dde-48e3-8538-e275c853b0b1)



