### PR TITLE
correct small JsDoc annotation errors

### DIFF
--- a/src/3d/curve3d.js
+++ b/src/3d/curve3d.js
@@ -193,6 +193,7 @@ JXG.createCurve3D = function (board, parents, attributes) {
     attr = el.setAttr2D(attr);
     el.element2D = view.create("curve", [[], []], attr);
     /**
+     * @class
      * @ignore
      */
     el.element2D.updateDataArray = function () {

--- a/src/3d/linspace3d.js
+++ b/src/3d/linspace3d.js
@@ -664,6 +664,7 @@ JXG.createPlane3D = function (board, parents, attributes) {
     el.element2D = view.create('curve', [[], []], attr);
 
     /**
+     * @class
      * @ignore
      */
     el.element2D.updateDataArray = function () {

--- a/src/3d/surface3d.js
+++ b/src/3d/surface3d.js
@@ -109,6 +109,7 @@ JXG.extend(
     /** @lends JXG.Surface3D.prototype */ {
 
         /**
+         * @class
          * @ignore
          */
         updateDataArray: function () {
@@ -230,6 +231,7 @@ JXG.createParametricSurface3D = function (board, parents, attributes) {
     el.element2D = view.create("curve", [[], []], attr);
 
     /**
+     * @class
      * @ignore
      */
     el.element2D.updateDataArray = function () {

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -3322,7 +3322,6 @@ JXG.extend(
                 this.mode = this.BOARD_MODE_NONE;
                 result = true;
             } else {
-                /** @ignore */
                 this.mouse = {
                     obj: null,
                     targets: [
@@ -3459,7 +3458,6 @@ JXG.extend(
             }
 
             // release dragged mouse object
-            /** @ignore */
             this.mouse = null;
         },
 

--- a/src/base/curve.js
+++ b/src/base/curve.js
@@ -2232,10 +2232,10 @@ JXG.registerElement("metapostspline", JXG.createMetapostSpline);
  * @class This element is used to provide a constructor for Riemann sums, which is realized as a special curve.
  * The returned element has the method Value() which returns the sum of the areas of the bars.
  * <p>
- * In case of type "simpson" and "trapezoidal", the horizontal line approximating the function value 
- * is replaced by a parabola or a secant. IN case of "simpson", 
- * the parabola is approximated visually by a polygonal chain of fixed step width. 
- * 
+ * In case of type "simpson" and "trapezoidal", the horizontal line approximating the function value
+ * is replaced by a parabola or a secant. IN case of "simpson",
+ * the parabola is approximated visually by a polygonal chain of fixed step width.
+ *
  * @pseudo
  * @description
  * @name Riemannsum
@@ -2339,7 +2339,7 @@ JXG.createRiemannsum = function (board, parents, attributes) {
     /**
      * Returns the value of the Riemann sum, i.e. the sum of the (signed) areas of the rectangles.
      * @name Value
-     * @memberOf Riemann.prototype
+     * @memberOf Riemannsum.prototype
      * @function
      * @returns {Number} value of Riemann sum.
      */

--- a/src/element/checkbox.js
+++ b/src/element/checkbox.js
@@ -41,6 +41,10 @@ import Env from "../utils/env";
 import Type from "../utils/type";
 
 var priv = {
+    /**
+     * @class
+     * @ignore
+     */
     CheckboxChangeEventHandler: function () {
         this._value = this.rendNodeCheckbox.checked;
         this.board.update();
@@ -55,7 +59,7 @@ var priv = {
  * <p>
  * The underlying HTML checkbox element can be accessed through the sub-object 'rendNodeCheck', e.g. to
  * add event listeners.
- * 
+ *
  * @pseudo
  * @description
  * @name Checkbox
@@ -141,7 +145,7 @@ var priv = {
  *                 b1.setText('Texts are changed');
  *             }],
  *             {cssStyle: 'width:200px'});
- * 
+ *
  * </pre><div id="JXG31c6d070-354b-4f09-aab9-9aaa796f730c" class="jxgbox" style="width: 300px; height: 300px;"></div>
  * <script type="text/javascript">
  *     (function() {
@@ -156,11 +160,11 @@ var priv = {
  *                     b1.setText('Texts are changed');
  *                 }],
  *                 {cssStyle: 'width:200px'});
- * 
+ *
  *     })();
- * 
+ *
  * </script><pre>
- * 
+ *
  */
 JXG.createCheckbox = function (board, parents, attributes) {
     var t,
@@ -219,6 +223,10 @@ JXG.createCheckbox = function (board, parents, attributes) {
         return this._value;
     };
 
+     /**
+     * @class
+     * @ignore
+     */
     t.update = function () {
         if (this.needsUpdate) {
             JXG.Text.prototype.update.call(this);

--- a/src/element/comb.js
+++ b/src/element/comb.js
@@ -188,9 +188,10 @@ JXG.createComb = function (board, parents, attributes) {
 
     attr = Type.copyAttributes(attributes, board.options, 'comb');
     // Type.merge(attr, Type.copyAttributes(attributes, board.options, 'comb', 'curve'));
-    c = board.create('curve', [[0], [0]], attr);
+     c = board.create('curve', [[0], [0]], attr);
 
     /**
+     * @class
      * @ignore
      */
     c.updateDataArray = function () {

--- a/src/element/composition.js
+++ b/src/element/composition.js
@@ -128,6 +128,7 @@ JXG.createOrthogonalProjection = function (board, parents, attributes) {
 
     attr = Type.copyAttributes(attributes, board.options, "orthogonalprojection");
 
+    /** @type t {JXG.Element} */
     t = board.create(
         "point",
         [
@@ -776,6 +777,7 @@ JXG.createParallelPoint = function (board, parents, attributes) {
     }
 
     attr = Type.copyAttributes(attributes, board.options, 'parallelpoint');
+    /** @type p {JXG.Element} */
     p = board.create(
         "point",
         [
@@ -2490,7 +2492,7 @@ JXG.createReflection = function (board, parents, attributes) {
  * @pseudo
  * @description A mirror element is determined by the reflection of a given point, line, circle, curve, polygon across another given point.
  * @constructor
- * @name Mirrorelement
+ * @name mirrorelement
  * @type JXG.GeometryElement
  * @augments JXG.GeometryElement
  * @throws {Error} If the element cannot be constructed with the given parent objects an exception is thrown.
@@ -2935,6 +2937,7 @@ JXG.createIntegral = function (board, parents, attributes) {
 
     /**
      * documented in JXG.Curve
+     * @class
      * @ignore
      */
     p.updateDataArray = function () {
@@ -3317,6 +3320,10 @@ JXG.createInequality = function (board, parents, attributes) {
         a.hasPoint = function () {
             return false;
         };
+
+        /**
+         * @ignore
+         */
         a.updateDataArray = function () {
             var i1,
                 i2,
@@ -3484,6 +3491,7 @@ JXG.createInequality = function (board, parents, attributes) {
         };
 
         // Previous code:
+        /** @ignore */
         a.hasPoint = function () {
             return false;
         };

--- a/src/element/conic.js
+++ b/src/element/conic.js
@@ -207,6 +207,7 @@ JXG.createEllipse = function (board, parents, attributes) {
         attr_center
     );
 
+    /** type curve {JGX.Element} */
     curve = board.create(
         "curve",
         [

--- a/src/element/input.js
+++ b/src/element/input.js
@@ -41,9 +41,15 @@ import Env from "../utils/env";
 import Type from "../utils/type";
 
 /**
+ * @class
  * @ignore
  */
 var priv = {
+     /**
+     * @class
+     * @ignore
+     */
+
     InputInputEventHandler: function (evt) {
         this._value = this.rendNodeInput.value;
         this.board.update();
@@ -61,7 +67,7 @@ var priv = {
  * <p>
  * The underlying HTML input field can be accessed through the sub-object 'rendNodeInput', e.g. to
  * add event listeners.
- * 
+ *
  * @pseudo
  * @description
  * @name Input
@@ -124,19 +130,19 @@ var priv = {
  *      t1_board.update();
  *  }
  * </script><pre>
- * 
+ *
  * @example
  * // Add the `keyup` event to an input field
  * var A = board.create('point', [3, -2]);
  * var i = board.create('input', [-4, -4, "1", "x "]);
- * 
+ *
  * i.rendNodeInput.addEventListener("keyup", ( function () {
  *    var x = parseFloat(this.value);
  *    if (!isNaN(x)) {
  * 	   A.moveTo([x, 3], 100);
  *    }
  * }));
- * 
+ *
  * </pre><div id="JXG81c84fa7-3f36-4874-9e0f-d4b9e93e755b" class="jxgbox" style="width: 300px; height: 300px;"></div>
  * <script type="text/javascript">
  *     (function() {
@@ -144,28 +150,28 @@ var priv = {
  *             {boundingbox: [-5, 5, 5, -5], axis: true, showcopyright: false, shownavigation: false});
  *     var A = board.create('point', [3, -2]);
  *     var i = board.create('input', [-4, -4, "1", "x "]);
- *     
+ *
  *     i.rendNodeInput.addEventListener("keyup", ( function () {
  *        var x = parseFloat(this.value);
  *        if (!isNaN(x)) {
  *     	    A.moveTo([x, 3], 100);
  *        }
  *     }));
- * 
+ *
  *     })();
- * 
+ *
  * </script><pre>
- * 
+ *
  * @example
  * // Add the `change` event to an input field
  * var A = board.create('point', [3, -2]);
  * var i = board.create('input', [-4, -4, "1", "x "]);
- * 
+ *
  * i.rendNodeInput.addEventListener("change", ( function () {
  *    var x = parseFloat(i.Value());
  *    A.moveTo([x, 2], 100);
  * }));
- * 
+ *
  * </pre><div id="JXG51c4d78b-a7ad-4c34-a983-b3ddae6192d7" class="jxgbox" style="width: 300px; height: 300px;"></div>
  * <script type="text/javascript">
  *     (function() {
@@ -173,29 +179,29 @@ var priv = {
  *             {boundingbox: [-8, 8, 8,-8], axis: true, showcopyright: false, shownavigation: false});
  *     var A = board.create('point', [3, -2]);
  *     var i = board.create('input', [-4, -4, "1", "x "]);
- *     
+ *
  *     i.rendNodeInput.addEventListener("change", ( function () {
  *        var x = parseFloat(i.Value());
  *        A.moveTo([x, 2], 100);
  *     }));
- * 
+ *
  *     })();
- * 
+ *
  * </script><pre>
- * 
- * 
+ *
+ *
  * @example
  *   Apply CSS classes to label and input tag
  *     &lt;style&gt;
  *         div.JXGtext_inp {
  *             font-weight: bold;
  *         }
- * 
+ *
  *         // Label
  *         div.JXGtext_inp > span > span {
  *             padding: 3px;
  *         }
- * 
+ *
  *         // Input field
  *         div.JXGtext_inp > span > input {
  *             width: 100px;
@@ -203,21 +209,21 @@ var priv = {
  *             border-radius: 25px;
  *         }
  *     &lt;/style&gt;
- * 
+ *
  * var inp = board.create('input', [-6, 1, 'x', 'y'], {
  *      CssClass: 'JXGtext_inp', HighlightCssClass: 'JXGtext_inp'
  * });
- * 
+ *
  * </pre>
  *         <style>
  *             div.JXGtext_inp {
  *                 font-weight: bold;
  *             }
- *     
+ *
  *             div.JXGtext_inp > span > span {
  *                 padding: 3px;
  *             }
- *     
+ *
  *             div.JXGtext_inp > span > input {
  *                 width: 100px;
  *                 border: solid 4px red;
@@ -230,10 +236,10 @@ var priv = {
  *         var board = JXG.JSXGraph.initBoard('JXGa3642ebd-a7dc-41ac-beb2-0c9e705ab8b4',
  *             {boundingbox: [-8, 8, 8,-8], axis: true, showcopyright: false, shownavigation: false});
  *         var inp = board.create('input', [-6, 1, 'x', 'y'], {CssClass: 'JXGtext_inp', HighlightCssClass: 'JXGtext_inp'});
- * 
+ *
  *     })();
  * </script><pre>
- * 
+ *
  */
 JXG.createInput = function (board, parents, attributes) {
     var t,
@@ -268,6 +274,11 @@ JXG.createInput = function (board, parents, attributes) {
     t.setText(parents[3]);
 
     t._value = parents[2];
+
+     /**
+     * @class
+     * @ignore
+     */
     t.update = function () {
         if (this.needsUpdate) {
             JXG.Text.prototype.update.call(this);
@@ -327,6 +338,12 @@ JXG.createInput = function (board, parents, attributes) {
      * </script><pre>
      *
      */
+
+     /**
+     * @class
+     * @ignore
+     */
+
     t.set = function (val) {
         this._value = val;
         this.rendNodeInput.value = val;

--- a/src/element/smartlabel.js
+++ b/src/element/smartlabel.js
@@ -209,6 +209,7 @@ JXG.createSmartLabel = function (board, parents, attributes) {
         attr = Type.copyAttributes(attributes, board.options, 'smartlabelpoint');
 
     } else if (p.elementClass === Const.OBJECT_CLASS_LINE) {
+        /** @type attr {attrArray} */
         attr = Type.copyAttributes(attributes, board.options, 'smartlabelline');
         attr.rotate = function () { return Math.atan(p.getSlope()) * 180 / Math.PI; };
         attr.visible = function () { return (p.L() < 1.5) ? false : true; };

--- a/src/element/vectorfield.js
+++ b/src/element/vectorfield.js
@@ -162,6 +162,8 @@ JXG.createVectorField = function(board, parents, attributes) {
     }
 
     attr = Type.copyAttributes(attributes, board.options, 'vectorfield');
+
+    /** @type { JXG.Curve } */
     el = board.create('curve', [[], []], attr);
     el.elType = 'vectorfield';
 

--- a/src/math/numerics.js
+++ b/src/math/numerics.js
@@ -2522,7 +2522,7 @@ Mat.Numerics = {
      * @param {Array} dataY Array containing the y-coordinates of the data set,
      * @returns {function} A function of one parameter which returns the value of the regression polynomial of the given degree.
      * It possesses the method getTerm() which returns the string containing the function term of the polynomial.
-     * The function returned will throw an exception, if the data set is malformed. 
+     * The function returned will throw an exception, if the data set is malformed.
      * @memberof JXG.Math.Numerics
      */
     regressionPolynomial: function (degree, dataX, dataY) {
@@ -2654,6 +2654,7 @@ Mat.Numerics = {
             return s;
         };
 
+        /** @ignore */
         fct.getTerm = function () {
             return term;
         };

--- a/src/math/qdt.js
+++ b/src/math/qdt.js
@@ -83,7 +83,7 @@ Mat.Quadtree = function (bbox, config, parent) {
     /**
      * Parent quad tree or null if there is not parent.
      *
-     * @name JXG.Math.Quadtree#northWest
+     * @name JXG.Math.Quadtree#parent
      * @type JXG.Math.Quadtree
      *
      */
@@ -244,7 +244,7 @@ Type.extend(
 
         /**
          * Retrieve the smallest quad tree that contains the given coordinate pair.
-         * @name JXG.Math.Quadtree#_query
+         * @name JXG.Math.Quadtree#query
          * @param {JXG.Coords|Number} xp
          * @param {Number} y
          * @returns {Boolean|JXG.Quadtree} The quad tree if the point is found, false

--- a/src/options.js
+++ b/src/options.js
@@ -1215,14 +1215,14 @@ JXG.Options = {
          *   needShift: true,  // mouse wheel zooming needs pressing of the shift key
          *   min: 0.001,       // minimal values of {@link JXG.Board#zoomX} and {@link JXG.Board#zoomY}, limits zoomOut
          *   max: 1000.0,      // maximal values of {@link JXG.Board#zoomX} and {@link JXG.Board#zoomY}, limits zoomIn
-         *   
+         *
          *   pinch: true,      // by pinch-to-zoom gesture on touch devices
          *   pinchHorizontal: true, // Allow pinch-to-zoom to zoom only horizontal axis
          *   pinchVertical: true,   // Allow pinch-to-zoom to zoom only vertical axis
          *   pinchSensitivity: 7    // Sensitivity (in degrees) for recognizing horizontal or vertical pinch-to-zoom gestures.
          * }
          * </pre>
-         * 
+         *
          * If the zoom buttons are visible, zooming is still possible, regardless of zoom.enabled:true/false.
          * If this should be prevented, set showZoom:false.
          *
@@ -3851,7 +3851,7 @@ JXG.Options = {
          * Attributes for center point.
          *
          * @type Point
-         * @name Circle#center
+         * @name Circle#point2
          */
         point2: {
             fillColor: Color.palette.red,
@@ -4244,11 +4244,11 @@ JXG.Options = {
          */
         plotVersion: 2,
 
-        /**
-         * Attributes for circle label.
+/**
+         * Attributes for curve label.
          *
          * @type Label
-         * @name Circle#label
+         * @name Curve#label
          */
         label: {
             position: 'lft'
@@ -5884,6 +5884,7 @@ JXG.Options = {
 
     /* special prescribed angle options
     * Not yet implemented. But angle.setAngle(val) is implemented.
+
     */
     prescribedangle: {
         /**#@+
@@ -5894,7 +5895,8 @@ JXG.Options = {
          * Attributes for the helper point of the prescribed angle.
          *
          * @type Point
-         * @name PrescribedAngle#anglePoint
+         * @name Prescribedangle#anglePoint
+         * @ignore
          */
         anglePoint: {
             size: 2,
@@ -5917,8 +5919,8 @@ JXG.Options = {
          * Attributes of circle center, i.e. the center of the circle,
          * if a circle is the mirror element and the transformation type is 'Euclidean'
          *
-         * @type Point
-         * @name Mirrorelement#center
+         * @type center
+         * @name Prescribedangle#center
          */
         center: {},
 
@@ -6010,7 +6012,7 @@ JXG.Options = {
          * Attributes for the polygon label.
          *
          * @type Label
-         * @name Polygon#label
+         * @name regularPolygon#label
          */
         label: {
             offset: [0, 0]
@@ -6875,7 +6877,7 @@ JXG.Options = {
         /**
          * The precision of the tape measure value displayed in the optional text.
          * @memberOf Tapemeasure.prototype
-         * @name precision
+         * @name digits
          * @type Number
          * @default 2
          */
@@ -7719,6 +7721,10 @@ JXG.Options = {
          */
         rotate: 0,
 
+        /**
+         * @name visible
+         * @default true
+         */
         visible: true,
 
         /**

--- a/src/renderer/svg.js
+++ b/src/renderer/svg.js
@@ -2156,6 +2156,7 @@ JXG.extend(
             }
 
             // Display the SVG string as data-uri in an HTML img.
+            /** {ignore} */
             tmpImg = new Image();
             svg = this.dumpToDataURI(ignoreTexts);
             tmpImg.src = svg;

--- a/src/utils/expect.js
+++ b/src/utils/expect.js
@@ -41,6 +41,9 @@ import Type from "./type";
 import Const from "../base/constants";
 import Coords from "../base/coords";
 
+/**
+ * @class
+ */
 var Expect = {
     /**
      * Apply an expect method on every element of an array.


### PR DESCRIPTION
Hi, this PR fixes about 60 'low-hanging' annotation errors.   

Some of them are just 'cut-and-paste' errors.  This image gives an example.  The comment and code for 'northWest' (just below) was copied, but only the code was corrected to 'parent'.    This group will slightly improve your already excellent documentation.

![quadtree](https://github.com/jsxgraph/jsxgraph/assets/11073753/6c8eba37-8d2e-4414-9899-d46a5cb9db2e)

Most of the others are due to the simple-minded nature of JsDoc's parser.  It reads the file as a single string and uses REGEX to extract annotations, without any analysis of the code.  All the problems were with *@ignore* tags in one way or another.  Some fixes will improve the documentation, others will simply clear an error message in JsDoc.  A common problem is that an *@ignore* without a *@type* or *@class* may get associated with the wrong symbol.

-----

About half of the remaining 200 errors are caused by a single line in JessieCode, which I have not yet tried to understand.

The remainder are because JsDoc gets confused by identical names that appear both in *options.js* and in the elements that use them.  The code is valid, but JsDoc's symbol table is too simple.  I am curious about whether this can be overcome, and will continue to poke a bit.

-----

For my own goal:  I learned enough from this exercise to see how I can create a D.TS file mechanically.  The function definitions can be extracted  from the JsDoc symbol table, and interface definitions from *options.js*  and *options3d.js*.  

But I am less sure that it is a good idea.  I didn't realize how manual the linkage between options, functions, and JsDoc annotations is, and how much work it is to maintain the three of them separately.   TypeScript is very fussy.  Small discrepancies between the three domains don't cause problems now, and maybe it is better to let them lie.  

JSXGraph is a mammoth project; I was surprised to see how much math coding was included (and how little testing was included).  It was like digging at an archeological site.  This tiny project was a perfect way to begin learning how JSXGraph is structured.

-----

Finally, I am using VSCode, and there seems to be a difference in how our editors treat *trailing whitespace in block comments*.   This is causing a number of unnecessary 'diff' lines in GitHub, and I do not know how to fix this.  I cannot see how to change VSCode's trimming behavior just for comment blocks.  Sorry, it is ugly.  What editor do you use?






