### PR TITLE
minor corrections to comments for JsDoc3

### DIFF
--- a/src/3d/element3d.js
+++ b/src/3d/element3d.js
@@ -56,7 +56,8 @@ JXG.GeometryElement3D = function (view, elType) {
      * Link to the 2D element(s) used to visualize the 3D element
      * in a view. In case, there are several 2D elements, it is an array.
      *
-     * @type JXG.GeometryElement,Array
+     * @type Array
+     * @description JXG.GeometryElement,Array
      * @private
      *
      * @example

--- a/src/3d/linspace3d.js
+++ b/src/3d/linspace3d.js
@@ -73,7 +73,7 @@ JXG.Line3D = function (view, point, direction, range, attributes) {
      * Direction which - together with a point - defines the line. Array of numbers or functions (of length 3) or function
      * returning array of length 3.
      *
-     * @type Array,Function
+     * @type Array|Function
      * @see JXG.Line3D#point
      */
     this.direction = direction;
@@ -319,7 +319,7 @@ JXG.registerElement('line3d', JXG.createLine3D);
  * @augments JXG.GeometryElement3D
  * @augments JXG.GeometryElement
  * @param {View3D} view
- * @param {Point3D,Array} point
+ * @param {Point3D|Array} point
  * @param {Array} direction1
  * @param {Array} range1
  * @param {Array} direction2
@@ -347,7 +347,7 @@ JXG.Plane3D = function (view, point, dir1, range1, dir2, range2, attributes) {
      * Two linearly independent vectors - together with a point - define the plane. Each of these direction vectors is an
      * array of numbers or functions (of length 3) or function returning array of length 3.
      *
-     * @type Array,Function
+     * @type Array|Function
      *
      * @see JXG.Plane3D#point
      * @see JXG.Plane3D#direction2
@@ -358,7 +358,7 @@ JXG.Plane3D = function (view, point, dir1, range1, dir2, range2, attributes) {
      * Two linearly independent vectors - together with a point - define the plane. Each of these direction vectors is an
      * array of numbers or functions (of length 3) or function returning array of length 3.
      *
-     * @type Array,Function
+     * @type Array|Function
      * @see JXG.Plane3D#point
      * @see JXG.Plane3D#direction1
      */

--- a/src/3d/point3d.js
+++ b/src/3d/point3d.js
@@ -42,7 +42,7 @@ import Type from "../utils/type";
  * @augments JXG.GeometryElement3D
  * @augments JXG.GeometryElement
  * @param {JXG.View3D} view The 3D view the point is drawn on.
- * @param {Function,Array} F Array of numbers, array of functions or function returning an array with defines the user coordinates of the point.
+ * @param {Function|Array} F Array of numbers, array of functions or function returning an array with defines the user coordinates of the point.
  * @parame {JXG.GeometryElement3D} slide Object the 3D point should be bound to. If null, the point is a free point.
  * @param {Object} attributes An object containing visual properties like in {@link JXG.Options#point3d} and
  * {@link JXG.Options#elements}, and optional a name and an id.

--- a/src/3d/view3d.js
+++ b/src/3d/view3d.js
@@ -80,10 +80,11 @@ JXG.View3D = function (board, parents, attributes) {
     this.defaultAxes = null;
 
     /**
-     * 3D-to-2D transformation matrix
-     * @type  {Array} 3 x 4 matrix
+     * @type  {Array}
      * @private
-     */
+    */
+    // 3 x 4 matrix
+    // 3D-to-2D transformation matrix
     this.matrix3D = [
         [1, 0, 0, 0],
         [0, 1, 0, 0],
@@ -91,10 +92,10 @@ JXG.View3D = function (board, parents, attributes) {
     ];
 
     /**
-     * Lower left corner [x, y] of the 3D view if elevation and azimuth are set to 0.
      * @type array
      * @private
-     */
+    */
+    //     Lower left corner [x, y] of the 3D view if elevation and azimuth are set to 0.
     this.llftCorner = parents[0];
 
     /**
@@ -293,7 +294,7 @@ JXG.extend(
         // Combine the two projections
         this.matrix3D = Mat.matMatMult(mat,
             // Mat.matMatMult(shift2,
-                Mat.matMatMult(this.matrix3D, shift)
+            Mat.matMatMult(this.matrix3D, shift)
             //)
         );
 
@@ -305,7 +306,7 @@ JXG.extend(
         return this;
     },
 
-    removeObject: function(object, saveMethod) {
+    removeObject: function (object, saveMethod) {
         var i;
 
         // this.board.removeObject(object, saveMethod);
@@ -325,12 +326,12 @@ JXG.extend(
         }
 
         try {
-        //     // remove all children.
-        //     for (el in object.childElements) {
-        //         if (object.childElements.hasOwnProperty(el)) {
-        //             object.childElements[el].board.removeObject(object.childElements[el]);
-        //         }
-        //     }
+            //     // remove all children.
+            //     for (el in object.childElements) {
+            //         if (object.childElements.hasOwnProperty(el)) {
+            //             object.childElements[el].board.removeObject(object.childElements[el]);
+            //         }
+            //     }
 
             delete this.objects[object.id];
         } catch (e) {
@@ -349,8 +350,8 @@ JXG.extend(
      * The 3D coordinates are provides as three numbers x, y, z or one array of length 3.
      *
      * @param  {Number|Array} x
-     * @param  {[Number]} y
-     * @param  {[Number]} z
+     * @param  {Number[]} y
+     * @param  {Number[]} z
      * @returns {Array} Array of length 3 containing the projection on to the board
      * in homogeneous user coordinates.
      */
@@ -550,7 +551,7 @@ JXG.extend(
     /**
      * Generate mesh for a surface / plane.
      * Returns array [dataX, dataY] for a JSXGraph curve's updateDataArray function.
-     * @param {Array,Function} func
+     * @param {Array|Function} func
      * @param {Array} interval_u
      * @param {Array} interval_v
      * @returns Array

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1265,7 +1265,7 @@ JXG.extend(
          * @param {Object} finger1 Actual and previous position of finger 1
          * @param {Boolean} scalable Flag if element may be scaled
          * @param {Boolean} rotatable Flag if element may be rotated
-         * @returns
+         * @returns {Array}
          */
         getTwoFingerTransform(finger1, finger2, scalable, rotatable) {
             var crd,

--- a/src/base/chart.js
+++ b/src/base/chart.js
@@ -58,7 +58,7 @@ import Env from "../utils/env";
  * Use {@link JXG.Board#create} with type {@link Chart} instead.
  * @constructor
  * @augments JXG.GeometryElement
- * @param {String,JXG.Board} board The board the new chart is drawn on.
+ * @param {String|JXG.Board} board The board the new chart is drawn on.
  * @param {Array} parent data arrays for the chart
  * @param {Object} attributes Javascript object containing attributes like name, id and colors.
  *
@@ -150,7 +150,7 @@ JXG.extend(
         /**
          * Create line chart defined by two data arrays.
          *
-         * @param  {String,JXG.Board} board      The board the chart is drawn on
+         * @param  {String|JXG.Board} board      The board the chart is drawn on
          * @param  {Array} x          Array of x-coordinates
          * @param  {Array} y          Array of y-coordinates
          * @param  {Object} attributes  Javascript object containing attributes like colors
@@ -168,7 +168,7 @@ JXG.extend(
          * Create line chart that consists of a natural spline curve
          * defined by two data arrays.
          *
-         * @param  {String,JXG.Board} board      The board the chart is drawn on
+         * @param  {String|JXG.Board} board      The board the chart is drawn on
          * @param  {Array} x          Array of x-coordinates
          * @param  {Array} y          Array of y-coordinates
          * @param  {Object} attributes Javascript object containing attributes like colors
@@ -187,7 +187,7 @@ JXG.extend(
          * defined by two data arrays. The degree of the polynomial is supplied
          * through the attribute "degree" in attributes.
          *
-         * @param  {String,JXG.Board} board      The board the chart is drawn on
+         * @param  {String|JXG.Board} board      The board the chart is drawn on
          * @param  {Array} x          Array of x-coordinates
          * @param  {Array} y          Array of y-coordinates
          * @param  {Object} attributes Javascript object containing attributes like colors
@@ -219,7 +219,7 @@ JXG.extend(
          * <li> labels: array of labels
          * </ul>
          *
-         * @param  {String,JXG.Board} board      The board the chart is drawn on
+         * @param  {String|JXG.Board} board      The board the chart is drawn on
          * @param  {Array} x          Array of x-coordinates
          * @param  {Array} y          Array of y-coordinates
          * @param  {Object} attributes Javascript object containing attributes like colors
@@ -347,7 +347,7 @@ JXG.extend(
          * <li> infoboxArray (Array): Texts for the infobox
          * </ul>
          *
-         * @param  {String,JXG.Board} board      The board the chart is drawn on
+         * @param  {String|JXG.Board} board      The board the chart is drawn on
          * @param  {Array} x          Array of x-coordinates
          * @param  {Array} y          Array of y-coordinates
          * @param  {Object} attributes Javascript object containing attributes like colors
@@ -383,7 +383,7 @@ JXG.extend(
          * <li> highlightOnSector (Boolean)
          * </ul>
          *
-         * @param  {String,JXG.Board} board      The board the chart is drawn on
+         * @param  {String|JXG.Board} board      The board the chart is drawn on
          * @param  {Array} y          Array of x-coordinates
          * @param  {Object} attributes Javascript object containing attributes like colors
          * @returns {Object}  with keys: "{sectors, points, midpoint}"
@@ -553,7 +553,7 @@ JXG.extend(
          * <li> circleStrokeWidth
          * </ul>
          *
-         * @param  {String,JXG.Board} board      The board the chart is drawn on
+         * @param  {String|JXG.Board} board      The board the chart is drawn on
          * @param  {Array} parents    Array of coordinates, e.g. [[x1, y1, z1], [x2, y2, z2], [x3, y3, z3]]
          * @param  {Object} attributes Javascript object containing attributes like colors
          * @returns {Object} with keys "{circles, lines, points, midpoint, polygons}"
@@ -968,7 +968,6 @@ JXG.extend(
 /**
  * @class Constructor for a chart.
  * @pseudo
- * @description
  * @name Chart
  * @augments JXG.Chart
  * @constructor
@@ -1346,7 +1345,7 @@ JXG.registerElement("chart", JXG.createChart);
  * access with the property "lines" of the element.
  * @constructor
  * @augments JXG.GeometryElement
- * @param {String,JXG.Board} board The board the new legend is drawn on.
+ * @param {String|JXG.Board} board The board the new legend is drawn on.
  * @param {Array} coords Coordinates of the left top point of the legend.
  * @param  {Object} attributes Attributes of the legend
  */
@@ -1384,7 +1383,7 @@ JXG.Legend.prototype = new GeometryElement();
  * Draw a vertical legend.
  *
  * @private
- * @param  {String,JXG.Board} board      The board the legend is drawn on
+ * @param  {String|JXG.Board} board      The board the legend is drawn on
  * @param  {Object} attributes Attributes of the legend
  */
 JXG.Legend.prototype.drawVerticalLegend = function (board, attributes) {
@@ -1442,7 +1441,6 @@ JXG.Legend.prototype.drawVerticalLegend = function (board, attributes) {
  * </ul>
  *
  * @pseudo
- * @description
  * @name Legend
  * @augments JXG.Legend
  * @constructor

--- a/src/base/constants.js
+++ b/src/base/constants.js
@@ -141,7 +141,7 @@ constants = /** @lends JXG */ {
      *
      */
     GENTYPE_REFLECTION: 4,
-    /**
+/**
      * @ignore
      * @deprecated, now use {@link JXG.GENTYPE_REFLECTION_ON_POINT}
      */
@@ -160,7 +160,8 @@ constants = /** @lends JXG */ {
     GENTYPE_INTERSECTION: 14,
     GENTYPE_CIRCLE: 15,
     /**
-     * @ignore @deprecated NOT USED ANY MORE SINCE SKETCHOMETRY 2.0 (only for old constructions needed)
+     * @ignore
+     * @deprecated NOT USED ANY MORE SINCE SKETCHOMETRY 2.0 (only for old constructions needed)
      */
     GENTYPE_CIRCLE2POINTS: 16,
 

--- a/src/base/coordselement.js
+++ b/src/base/coordselement.js
@@ -1624,10 +1624,10 @@ JXG.extend(
 
         /**
          * Animate the point.
-         * @param {Number,Function} direction The direction the glider is animated. Can be +1 or -1.
-         * @param {Number,Function} stepCount The number of steps in which the parent element is divided.
+         * @param {Number|Function} direction The direction the glider is animated. Can be +1 or -1.
+         * @param {Number|Function} stepCount The number of steps in which the parent element is divided.
          * Must be at least 1.
-         * @param {Number,Function} delay Time in msec between two animation steps. Default is 250.
+         * @param {Number|Function} delay Time in msec between two animation steps. Default is 250.
          * @returns {JXG.CoordsElement} Reference to iself.
          *
          * @name Glider#startAnimation

--- a/src/base/curve.js
+++ b/src/base/curve.js
@@ -1363,7 +1363,7 @@ JXG.extend(
 );
 
 /**
- * @class This element is used to provide a constructor for curve, which is just a wrapper for element {@link Curve}.
+ * @class  This element is used to provide a constructor for curve, which is just a wrapper for element {@link Curve}.
  * A curve is a mapping from R to R^2. t mapsto (x(t),y(t)). The graph is drawn for t in the interval [a,b].
  * <p>
  * The following types of curves can be plotted:
@@ -1373,13 +1373,13 @@ JXG.extend(
  *  <li> data plots: plot line segments through a given list of coordinates.
  * </ul>
  * @pseudo
- * @description
  * @name Curve
  * @augments JXG.Curve
  * @constructor
- * @type JXG.Curve
- *
- * @param {function,number_function,number_function,number_function,number} x,y,a_,b_ Parent elements for Parametric Curves.
+ * @type Object
+ * @description JXG.Curve
+
+ * @param {function,number_function,number_function,number_function,number}  x,y,a_,b_ Parent elements for Parametric Curves.
  *                     <p>
  *                     x describes the x-coordinate of the curve. It may be a function term in one variable, e.g. x(t).
  *                     In case of x being of type number, x(t) is set to  a constant function.
@@ -1396,14 +1396,18 @@ JXG.extend(
  *                     <p>
  *                     Default values are a=-10 and b=10.
  *                     </p>
- * @param {array_array,function,number} x,y Parent elements for Data Plots.
+ *
+ * @param {array_array,function,number}
+ *
+ * @description x,y Parent elements for Data Plots.
  *                     <p>
  *                     x and y are arrays contining the x and y coordinates of the data points which are connected by
  *                     line segments. The individual entries of x and y may also be functions.
  *                     In case of x being an array the curve type is data plot, regardless of the second parameter and
  *                     if additionally the second parameter y is a function term the data plot evaluates.
  *                     </p>
- * @param {function_array,function,number_function,number_function,number} r,offset_,a_,b_ Parent elements for Polar Curves.
+ * @param {function_array,function,number_function,number_function,number}
+ * @description r,offset_,a_,b_ Parent elements for Polar Curves.
  *                     <p>
  *                     The first parameter is a function term r(phi) describing the polar curve.
  *                     </p>
@@ -1582,7 +1586,6 @@ JXG.registerElement("curve", JXG.createCurve);
  * which is just a wrapper for element {@link Curve} with {@link JXG.Curve#X}()
  * set to x. The graph is drawn for x in the interval [a,b].
  * @pseudo
- * @description
  * @name Functiongraph
  * @augments JXG.Curve
  * @constructor
@@ -1636,7 +1639,6 @@ JXG.registerElement("plot", JXG.createFunctiongraph);
  * @class This element is used to provide a constructor for (natural) cubic spline curves.
  * Create a dynamic spline interpolated curve given by sample points p_1 to p_n.
  * @pseudo
- * @description
  * @name Spline
  * @augments JXG.Curve
  * @constructor
@@ -1786,7 +1788,6 @@ JXG.registerElement("spline", JXG.createSpline);
  * @class This element is used to provide a constructor for cardinal spline curves.
  * Create a dynamic cardinal spline interpolated curve given by sample points p_1 to p_n.
  * @pseudo
- * @description
  * @name Cardinalspline
  * @augments JXG.Curve
  * @constructor
@@ -1997,7 +1998,6 @@ JXG.registerElement("cardinalspline", JXG.createCardinalSpline);
  * @class This element is used to provide a constructor for metapost spline curves.
  * Create a dynamic metapost spline interpolated curve given by sample points p_1 to p_n.
  * @pseudo
- * @description
  * @name Metapostspline
  * @augments JXG.Curve
  * @constructor
@@ -2237,11 +2237,10 @@ JXG.registerElement("metapostspline", JXG.createMetapostSpline);
  * the parabola is approximated visually by a polygonal chain of fixed step width.
  *
  * @pseudo
- * @description
  * @name Riemannsum
  * @augments JXG.Curve
  * @constructor
- * @type JXG.Curve
+ * @type Curve
  * @param {function,array_number,function_string,function_function,number_function,number} f,n,type_,a_,b_ Parent elements of Riemannsum are a
  *         Either a function term f(x) describing the function graph which is filled by the Riemann bars, or
  *         an array consisting of two functions and the area between is filled by the Riemann bars.
@@ -2369,13 +2368,14 @@ JXG.registerElement("riemannsum", JXG.createRiemannsum);
 /**
  * @class This element is used to provide a constructor for trace curve (simple locus curve), which is realized as a special curve.
  * @pseudo
- * @description
  * @name Tracecurve
  * @augments JXG.Curve
  * @constructor
- * @type JXG.Curve
- * @param {Point,Point} Parent elements of Tracecurve are a
+ * @type Object
+ * @descript JXG.Curve
+ * @param {Point} Parent elements of Tracecurve are a
  *         glider point and a point whose locus is traced.
+ * @param {point}
  * @see JXG.Curve
  * @example
  * // Create trace curve.
@@ -2534,12 +2534,13 @@ JXG.registerElement("tracecurve", JXG.createTracecurve);
      *
      * In case the data points should be updated after creation time, they can be accessed by curve.xterm and curve.yterm.
      * @pseudo
-     * @description
      * @name Stepfunction
      * @augments JXG.Curve
      * @constructor
-     * @type JXG.Curve
-     * @param {Array,Array|Function} Parent elements of Stepfunction are two arrays containing the coordinates.
+     * @type Curve
+     * @description JXG.Curve
+     * @param {Array|Function} Parent1 elements of Stepfunction are two arrays containing the coordinates.
+     * @param {Array|Function} Parent2
      * @see JXG.Curve
      * @example
      * // Create step function.
@@ -2601,7 +2602,6 @@ JXG.registerElement("stepfunction", JXG.createStepfunction);
  * the (numerical) derivative of a given curve.
  *
  * @pseudo
- * @description
  * @name Derivative
  * @augments JXG.Curve
  * @constructor
@@ -2668,7 +2668,6 @@ JXG.registerElement("derivative", JXG.createDerivative);
  * If one element is a curve, it has to be closed.
  * The resulting element is of type curve.
  * @pseudo
- * @description
  * @name CurveIntersection
  * @param {JXG.Curve|JXG.Polygon|JXG.Circle} curve1 First element which is intersected
  * @param {JXG.Curve|JXG.Polygon|JXG.Circle} curve2 Second element which is intersected
@@ -2724,7 +2723,6 @@ JXG.createCurveIntersection = function (board, parents, attributes) {
  * If one element is a curve, it has to be closed.
  * The resulting element is of type curve.
  * @pseudo
- * @description
  * @name CurveUnion
  * @param {JXG.Curve|JXG.Polygon|JXG.Circle} curve1 First element defining the union
  * @param {JXG.Curve|JXG.Polygon|JXG.Circle} curve2 Second element defining the union
@@ -2780,7 +2778,6 @@ JXG.createCurveUnion = function (board, parents, attributes) {
  * If one element is a curve, it has to be closed.
  * The resulting element is of type curve.
  * @pseudo
- * @description
  * @name CurveDifference
  * @param {JXG.Curve|JXG.Polygon|JXG.Circle} curve1 First element from which the second element is "subtracted"
  * @param {JXG.Curve|JXG.Polygon|JXG.Circle} curve2 Second element which is subtracted from the first element
@@ -2839,7 +2836,6 @@ JXG.registerElement("curveunion", JXG.createCurveUnion);
  * @class Box plot curve. The direction of the box plot can be either vertical or horizontal which
  * is controlled by the attribute "dir".
  * @pseudo
- * @description
  * @name Boxplot
  * @param {Array} quantiles Array conatining at least five quantiles. The elements can be of type number, function or string.
  * @param {Number|Function} axis Axis position of the box plot

--- a/src/base/element.js
+++ b/src/base/element.js
@@ -440,11 +440,11 @@ JXG.extend(
         },
 
         /**
-         * Adds the given object to the descendants list of this object and all its child objects.
          * @param {JXG.GeometryElement} obj The element that is to be added to the descendants list.
          * @private
-         * @return
-         */
+         * @return this
+        */
+        // Adds the given object to the descendants list of this object and all its child objects.
         addDescendants: function (obj) {
             var el;
 
@@ -2262,14 +2262,14 @@ JXG.extend(
 
         /**
          * Format a number according to the locale set in the attribute "intl".
-         * If in the options of the intl-attribute "maximumFractionDigits" is not set, 
+         * If in the options of the intl-attribute "maximumFractionDigits" is not set,
          * the optional parameter digits is used instead.
          * See <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat">https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat</a>
          * for more  information about internationalization.
-         * 
+         *
          * @param {Number} value Number to be formatted
          * @param {Number} [digits=undefined] Optional number of digits
-         * @returns {String|Number} string containing the formatted number according to the locale 
+         * @returns {String|Number} string containing the formatted number according to the locale
          * or the number itself of the formatting is not possible.
          */
         formatNumberLocale: function(value, digits) {
@@ -2335,9 +2335,9 @@ JXG.extend(
 
         /**
          * Checks if locale is enabled in the attribute. This may be in the attributes of the board,
-         * or in the attributes of the text. The latter has higher priority. The board attribute is taken if 
+         * or in the attributes of the text. The latter has higher priority. The board attribute is taken if
          * attribute "intl.enabled" of the text element is set to 'inherit'.
-         * 
+         *
          * @returns {Boolean} if locale can be used for number formatting.
          */
         useLocale: function() {

--- a/src/base/foreignobject.js
+++ b/src/base/foreignobject.js
@@ -294,9 +294,9 @@ JXG.extend(
          * Set the width and height of the foreignObject. After setting a new size,
          * board.update() or foreignobject.fullUpdate()
          * has to be called to make the change visible.
-         * @param  {number, function, string} width  Number, function or string
+         * @param  {numbe|function|string} width  Number, function or string
          *                            that determines the new width of the foreignObject
-         * @param  {number, function, string} height Number, function or string
+         * @param  {number|function|string} height Number, function or string
          *                            that determines the new height of the foreignObject
          * @returns {JXG.ForeignObject} A reference to the element
          *
@@ -337,7 +337,6 @@ JXG.extend(
  * </p>
  *
  * @pseudo
- * @description
  * @name ForeignObject
  * @augments JXG.ForeignObject
  * @constructor

--- a/src/base/group.js
+++ b/src/base/group.js
@@ -336,9 +336,9 @@ JXG.extend(
 
         /**
          * @private
-         * Determine what the dragging of a group element should do:
-         * rotation, translation, scaling or nothing.
-         */
+        */
+        //  Determine what the dragging of a group element should do:
+        //  rotation, translation, scaling or nothing.
         _update_find_drag_type: function () {
             var el,
                 obj,
@@ -400,9 +400,9 @@ JXG.extend(
 
         /**
          * @private
-         * Determine the Euclidean coordinates of the centroid of the group.
          * @returns {Array} array of length two,
-         */
+        */
+        // Determine the Euclidean coordinates of the centroid of the group.
         _update_centroid_center: function () {
             var center, len, el;
 
@@ -425,8 +425,8 @@ JXG.extend(
 
         /**
          * @private
-         * Apply the transformation to all elements of the group
-         */
+        */
+        // Apply the transformation to all elements of the group
         _update_apply_transformation: function (drag, t) {
             var el, obj;
 
@@ -736,7 +736,6 @@ JXG.extend(
  *
  *
  * @pseudo
- * @description
  * @name Group
  * @augments JXG.Group
  * @constructor

--- a/src/base/image.js
+++ b/src/base/image.js
@@ -290,9 +290,9 @@ JXG.extend(
          * Set the width and height of the image. After setting a new size,
          * board.update() or image.fullUpdate()
          * has to be called to make the change visible.
-         * @param  {number, function, string} width  Number, function or string
+         * @param  {number|function|string} width  Number, function or string
          *                            that determines the new width of the image
-         * @param  {number, function, string} height Number, function or string
+         * @param  {number|function|string} height Number, function or string
          *                            that determines the new height of the image
          * @returns {JXG.GeometryElement} A reference to the element
          *
@@ -370,7 +370,6 @@ JXG.extend(
 /**
  * @class Displays an image.
  * @pseudo
- * @description
  * @name Image
  * @type JXG.Image
  * @augments JXG.Image

--- a/src/base/line.js
+++ b/src/base/line.js
@@ -56,7 +56,7 @@ import Type from "../utils/type";
  * type {@link Line}, {@link Arrow}, or {@link Axis} instead.
  * @constructor
  * @augments JXG.GeometryElement
- * @param {String,JXG.Board} board The board the new line is drawn on.
+ * @param {String|JXG.Board} board The board the new line is drawn on.
  * @param {Point} p1 Startpoint of the line.
  * @param {Point} p2 Endpoint of the line.
  * @param {Object} attributes Javascript object containing attributes like name, id and colors.
@@ -953,7 +953,6 @@ JXG.extend(
  * @class This element is used to provide a constructor for a general line. A general line is given by two points. By setting additional properties
  * a line can be used as an arrow and/or axis.
  * @pseudo
- * @description
  * @name Line
  * @augments JXG.Line
  * @constructor
@@ -1291,7 +1290,6 @@ JXG.registerElement("line", JXG.createLine);
  * and {@link Line#straightLast} properties set to false. If there is a third variable then the
  * segment has a fixed length (which may be a function, too).
  * @pseudo
- * @description
  * @name Segment
  * @augments JXG.Line
  * @constructor
@@ -1401,7 +1399,6 @@ JXG.registerElement("segment", JXG.createSegment);
  * {@link Line} with {@link Line#straightFirst}
  * and {@link Line#straightLast} properties set to false and {@link Line#lastArrow} set to true.
  * @pseudo
- * @description
  * @name Arrow
  * @augments JXG.Line
  * @constructor
@@ -1445,7 +1442,6 @@ JXG.registerElement("arrow", JXG.createArrow);
  * @class This element is used to provide a constructor for an axis. It's strictly spoken just a wrapper for element {@link Line} with {@link Line#straightFirst}
  * and {@link Line#straightLast} properties set to true. Additionally {@link Line#lastArrow} is set to true and default {@link Ticks} will be created.
  * @pseudo
- * @description
  * @name Axis
  * @augments JXG.Line
  * @constructor
@@ -1529,7 +1525,6 @@ JXG.registerElement("axis", JXG.createAxis);
  * @class With the element tangent the slope of a line, circle, or curve in a certain point can be visualized. A tangent is always constructed
  * by a glider on a line, circle, or curve and describes the tangent in the glider point on that line, circle, or curve.
  * @pseudo
- * @description
  * @name Tangent
  * @augments JXG.Line
  * @constructor
@@ -1967,7 +1962,6 @@ JXG.createTangent = function (board, parents, attributes) {
  * The radical axis passes through the intersection points when the circles intersect.
  * When a circle about the midpoint of circle centers, passing through the circle centers, intersects the circles, the polar lines pass through those intersection points.
  * @pseudo
- * @description
  * @name RadicalAxis
  * @augments JXG.Line
  * @constructor

--- a/src/base/point.js
+++ b/src/base/point.js
@@ -463,7 +463,6 @@ JXG.extend(
  * position directly.
  * @see Glider for a non-free point that is attached to another geometric element.
  * @pseudo
- * @description
  * @name Point
  * @augments JXG.Point
  * @constructor

--- a/src/base/text.js
+++ b/src/base/text.js
@@ -131,15 +131,15 @@ JXG.extend(
     /** @lends JXG.Text.prototype */ {
         /**
          * @private
-         * Test if the screen coordinates (x,y) are in a small stripe
-         * at the left side or at the right side of the text.
-         * Sensitivity is set in this.board.options.precision.hasPoint.
-         * If dragarea is set to 'all' (default), tests if the screen
-         * coordinates (x,y) are in within the text boundary.
          * @param {Number} x
          * @param {Number} y
          * @returns {Boolean}
-         */
+        */
+        // Test if the screen coordinates (x,y) are in a small stripe
+        // at the left side or at the right side of the text.
+        // Sensitivity is set in this.board.options.precision.hasPoint.
+        // If dragarea is set to 'all' (default), tests if the screen
+        // coordinates (x,y) are in within the text boundary.
         hasPoint: function (x, y) {
             var lft, rt, top, bot, ax, ay, type, r;
 
@@ -406,7 +406,7 @@ JXG.extend(
          * JSXGraph needs {@link JXG.Text#size} for applying rotations in IE and
          * for aligning text.
          *
-         * @return {[type]} [description]
+         * @return {this} [description]
          */
         updateSize: function () {
             var tmp,
@@ -1276,7 +1276,6 @@ JXG.extend(
  * If HTML should be displayed in an inbetween layer, conder to use an element of type {@link ForeignObject} (available in svg renderer, only).
  * </ul>
  * @pseudo
- * @description
  * @name Text
  * @augments JXG.Text
  * @constructor
@@ -1376,7 +1375,6 @@ JXG.registerElement("text", JXG.createText);
  * Labels are handled internally by JSXGraph, only. There is NO constructor "board.create('label', ...)".
  *
  * @pseudo
- * @description
  * @name Label
  * @augments JXG.Text
  * @constructor

--- a/src/base/ticks.js
+++ b/src/base/ticks.js
@@ -1666,7 +1666,6 @@ JXG.extend(
  * The default value is "left".
  *
  * @pseudo
- * @description
  * @name Ticks
  * @augments JXG.Ticks
  * @constructor
@@ -1741,7 +1740,6 @@ JXG.createTicks = function (board, parents, attributes) {
 /**
  * @class Hatches can be used to mark congruent lines or curves.
  * @pseudo
- * @description
  * @name Hatch
  * @augments JXG.Ticks
  * @constructor

--- a/src/base/transformation.js
+++ b/src/base/transformation.js
@@ -357,7 +357,7 @@ JXG.extend(
          * Applies a transformation once to a GeometryElement or an array of elements.
          * If it is a free point, then it can be dragged around later
          * and will overwrite the transformed coordinates.
-         * @param {JXG.Point,Array} p
+         * @param {JXG.Point|Array} p
          */
         applyOnce: function (p) {
             var c, len, i;
@@ -379,7 +379,7 @@ JXG.extend(
          * Binds a transformation to a GeometryElement or an array of elements. In every update of the
          * GeometryElement(s), the transformation is executed. That means, in order to immediately
          * apply the transformation, a call of board.update() has to follow.
-         * @param  {Array,JXG.Object} p JXG.Object or array of JXG.Object to
+         * @param  {Array|JXG.Object} p JXG.Object or array of JXG.Object to
          *                            which the transformation is bound to.
          */
         bindTo: function (p) {
@@ -483,7 +483,7 @@ JXG.extend(
  * <p>
  * Internally, a transformation is applied to an element by multiplying the 3x3 matrix from the left to
  * the homogeneous coordinates of the element. JSXGraph represents homogeneous coordinates in the order
- * (z, x, y). The matrix has the form 
+ * (z, x, y). The matrix has the form
  * <pre>
  * ( a  b  c )   ( z )
  * ( d  e  f ) * ( x )
@@ -493,13 +493,13 @@ JXG.extend(
  * In this case, finite points will stay finite. This is not the case for general projective coordinates.
  * <p>
  * Transformations acting on texts and images are considered to be affine, i.e. b and c are ignored.
- * 
+ *
  * @name Transformation
  * @augments JXG.Transformation
  * @constructor
  * @type JXG.Transformation
  * @throws {Exception} If the element cannot be constructed with the given parent objects an exception is thrown.
- * @param {numbers,functions} parameters The parameters depend on the transformation type, supplied as attribute 'type'.
+ * @param {numbers|functions} parameters The parameters depend on the transformation type, supplied as attribute 'type'.
  * Possible transformation types are
  * <ul><li> 'translate'
  * <li> 'scale'
@@ -764,17 +764,17 @@ JXG.extend(
      * var p0 = board.create('point', [0, 0], {name: 'p_0'});
      * var p1 = board.create('point', [3, 0], {name: 'p_1'});
      * var txt = board.create('text',[0.5, 0, 'Hello World'], {display:'html'});
-     * 
+     *
      * // If p_0 is dragged, translate p_1 and text accordingly
      * var tOff = board.create('transform', [() => p0.X(), () => p0.Y()], {type:'translate'});
      * tOff.bindTo(txt);
      * tOff.bindTo(p1);
-     * 
+     *
      * // Rotate text around p_0 by dragging point p_1
      * var tRot = board.create('transform', [
      *     () => Math.atan2(p1.Y() - p0.Y(), p1.X() - p0.X()), p0], {type:'rotate'});
      * tRot.bindTo(txt);
-     * 
+     *
      * // Scale text by dragging point "p_1"
      * // We do this by
      * // - moving text by -p_0 (inverse of transformation tOff),
@@ -790,7 +790,7 @@ JXG.extend(
      *         () => p1.Dist(p0) / 3
      * ], {type:'scale'});
      * tOffInv.bindTo(txt); tScale.bindTo(txt); tOff.bindTo(txt);
-     * 
+     *
      * </pre><div id="JXG50d6d546-3b91-41dd-8c0f-3eaa6cff7e66" class="jxgbox" style="width: 300px; height: 300px;"></div>
      * <script type="text/javascript">
      *     (function() {
@@ -799,17 +799,17 @@ JXG.extend(
      *     var p0 = board.create('point', [0, 0], {name: 'p_0'});
      *     var p1 = board.create('point', [3, 0], {name: 'p_1'});
      *     var txt = board.create('text',[0.5, 0, 'Hello World'], {display:'html'});
-     *     
+     *
      *     // If p_0 is dragged, translate p_1 and text accordingly
      *     var tOff = board.create('transform', [() => p0.X(), () => p0.Y()], {type:'translate'});
      *     tOff.bindTo(txt);
      *     tOff.bindTo(p1);
-     *     
+     *
      *     // Rotate text around p_0 by dragging point p_1
      *     var tRot = board.create('transform', [
      *         () => Math.atan2(p1.Y() - p0.Y(), p1.X() - p0.X()), p0], {type:'rotate'});
      *     tRot.bindTo(txt);
-     *     
+     *
      *     // Scale text by dragging point "p_1"
      *     // We do this by
      *     // - moving text by -p_0 (inverse of transformation tOff),
@@ -825,11 +825,11 @@ JXG.extend(
      *             () => p1.Dist(p0) / 3
      *     ], {type:'scale'});
      *     tOffInv.bindTo(txt); tScale.bindTo(txt); tOff.bindTo(txt);
-     * 
+     *
      *     })();
-     * 
+     *
      * </script><pre>
-     * 
+     *
  */
 JXG.createTransform = function (board, parents, attributes) {
     return new JXG.Transformation(board, attributes.type, parents);

--- a/src/element/button.js
+++ b/src/element/button.js
@@ -59,7 +59,6 @@ var priv = {
  * add event listeners.
  *
  * @pseudo
- * @description
  * @name Button
  * @augments Text
  * @constructor

--- a/src/element/checkbox.js
+++ b/src/element/checkbox.js
@@ -61,7 +61,6 @@ var priv = {
  * add event listeners.
  *
  * @pseudo
- * @description
  * @name Checkbox
  * @augments Text
  * @constructor

--- a/src/element/composition.js
+++ b/src/element/composition.js
@@ -128,7 +128,7 @@ JXG.createOrthogonalProjection = function (board, parents, attributes) {
 
     attr = Type.copyAttributes(attributes, board.options, "orthogonalprojection");
 
-    /** @type t {JXG.Element} */
+    /** @type {JXG.Element} */
     t = board.create(
         "point",
         [
@@ -777,7 +777,7 @@ JXG.createParallelPoint = function (board, parents, attributes) {
     }
 
     attr = Type.copyAttributes(attributes, board.options, 'parallelpoint');
-    /** @type p {JXG.Element} */
+    /** @type {JXG.Element} */
     p = board.create(
         "point",
         [

--- a/src/element/conic.js
+++ b/src/element/conic.js
@@ -48,7 +48,6 @@ import Type from "../utils/type";
  * @class This element is used to provide a constructor for an ellipse. An ellipse is given by two points (the foci) and a third point on the ellipse or
  * the length of the major axis.
  * @pseudo
- * @description
  * @name Ellipse
  * @augments Conic
  * @constructor
@@ -327,7 +326,6 @@ JXG.createEllipse = function (board, parents, attributes) {
  * @class This element is used to provide a constructor for an hyperbola. An hyperbola is given by two points (the foci) and a third point on the hyperbola or
  * the length of the major axis.
  * @pseudo
- * @description
  * @name Hyperbola
  * @augments Conic
  * @constructor
@@ -546,11 +544,11 @@ JXG.createHyperbola = function (board, parents, attributes) {
 /**
  * @class This element is used to provide a constructor for a parabola. A parabola is given by one point (the focus) and a line (the directrix).
  * @pseudo
- * @description
  * @name Parabola
  * @augments Conic
  * @constructor
- * @type JXG.Curve
+ * @type Object
+ * @description JXG.Curve
  * @throws {Exception} If the element cannot be constructed with the given parent objects an exception is thrown.
  * @param {JXG.Point,array_JXG.Line} point,line Parent elements are a point and a line or a pair of coordinates.
  * Optional parameters three and four are numbers which define the curve length (e.g. start/end). Default values are -pi and pi.
@@ -769,7 +767,6 @@ JXG.createParabola = function (board, parents, attributes) {
  *     board.create('conic', [A, C, F, B/2, D/2, E/2]);
  * </pre>
  * @pseudo
- * @description
  * @name Conic
  * @augments JXG.Curve
  * @constructor

--- a/src/element/input.js
+++ b/src/element/input.js
@@ -69,7 +69,6 @@ var priv = {
  * add event listeners.
  *
  * @pseudo
- * @description
  * @name Input
  * @augments Text
  * @constructor

--- a/src/element/measure.js
+++ b/src/element/measure.js
@@ -45,7 +45,6 @@ import GeometryElement from "../base/element";
 /**
  * @class A tape measure can be used to measure distances between points.
  * @pseudo
- * @description
  * @name Tapemeasure
  * @augments Segment
  * @constructor

--- a/src/element/sector.js
+++ b/src/element/sector.js
@@ -656,7 +656,7 @@ JXG.createSector = function (board, parents, attributes) {
     /**
      * Overwrite the Radius method of the sector.
      * Used in {@link GeometryElement#setAttribute}.
-     * @param {Number, Function} value New radius.
+     * @param {Number|Function} value New radius.
      */
     el.setRadius = function (val) {
         var res,

--- a/src/element/slider.js
+++ b/src/element/slider.js
@@ -48,7 +48,6 @@ import Point from "../base/point";
 /**
  * @class A slider can be used to choose values from a given range of numbers.
  * @pseudo
- * @description
  * @name Slider
  * @augments Glider
  * @constructor

--- a/src/element/smartlabel.js
+++ b/src/element/smartlabel.js
@@ -209,7 +209,6 @@ JXG.createSmartLabel = function (board, parents, attributes) {
         attr = Type.copyAttributes(attributes, board.options, 'smartlabelpoint');
 
     } else if (p.elementClass === Const.OBJECT_CLASS_LINE) {
-        /** @type attr {attrArray} */
         attr = Type.copyAttributes(attributes, board.options, 'smartlabelline');
         attr.rotate = function () { return Math.atan(p.getSlope()) * 180 / Math.PI; };
         attr.visible = function () { return (p.L() < 1.5) ? false : true; };

--- a/src/jsxgraph.js
+++ b/src/jsxgraph.js
@@ -551,7 +551,8 @@ JXG.JSXGraph = {
 
     /**
      * Delete a board and all its contents.
-     * @param {JXG.Board,String} board id of or reference to the DOM element in which the board is drawn.
+     * @param {JXG.Board|String} board id of or reference to the DOM element in which the board is drawn.
+     *
      */
     freeBoard: function (board) {
         var el;

--- a/src/math/complex.js
+++ b/src/math/complex.js
@@ -105,7 +105,7 @@ JXG.extend(
 
         /**
          * Add another complex number to this complex number.
-         * @param {JXG.Complex,Number} c A JavaScript number or a JXG.Complex object to be added to the current object.
+         * @param {JXG.Complex|Number} c A JavaScript number or a JXG.Complex object to be added to the current object.
          * @returns {JXG.Complex} Reference to this complex number
          */
         add: function (c) {
@@ -121,7 +121,7 @@ JXG.extend(
 
         /**
          * Subtract another complex number from this complex number.
-         * @param {JXG.Complex,Number} c A JavaScript number or a JXG.Complex object to subtract from the current object.
+         * @param {JXG.Complex|Number} c A JavaScript number or a JXG.Complex object to subtract from the current object.
          * @returns {JXG.Complex} Reference to this complex number
          */
         sub: function (c) {
@@ -137,7 +137,7 @@ JXG.extend(
 
         /**
          * Multiply another complex number to this complex number.
-         * @param {JXG.Complex,Number} c A JavaScript number or a JXG.Complex object to
+         * @param {JXG.Complex|Number} c A JavaScript number or a JXG.Complex object to
          * multiply with the current object.
          * @returns {JXG.Complex} Reference to this complex number
          */
@@ -161,7 +161,7 @@ JXG.extend(
 
         /**
          * Divide this complex number by the given complex number.
-         * @param {JXG.Complex,Number} c A JavaScript number or a JXG.Complex object to
+         * @param {JXG.Complex|Number} c A JavaScript number or a JXG.Complex object to
          * divide the current object by.
          * @returns {JXG.Complex} Reference to this complex number
          */
@@ -230,8 +230,8 @@ JXG.C = {};
 
 /**
  * Add two (complex) numbers z1 and z2 and return the result as a (complex) number.
- * @param {JXG.Complex,Number} z1 Summand
- * @param {JXG.Complex,Number} z2 Summand
+ * @param {JXG.Complex|Number} z1 Summand
+ * @param {JXG.Complex|Number} z2 Summand
  * @returns {JXG.Complex} A complex number equal to the sum of the given parameters.
  */
 JXG.C.add = function (z1, z2) {
@@ -242,8 +242,8 @@ JXG.C.add = function (z1, z2) {
 
 /**
  * Subtract two (complex) numbers z1 and z2 and return the result as a (complex) number.
- * @param {JXG.Complex,Number} z1 Minuend
- * @param {JXG.Complex,Number} z2 Subtrahend
+ * @param {JXG.Complex|Number} z1 Minuend
+ * @param {JXG.Complex|Number} z2 Subtrahend
  * @returns {JXG.Complex} A complex number equal to the difference of the given parameters.
  */
 JXG.C.sub = function (z1, z2) {
@@ -254,8 +254,8 @@ JXG.C.sub = function (z1, z2) {
 
 /**
  * Multiply two (complex) numbers z1 and z2 and return the result as a (complex) number.
- * @param {JXG.Complex,Number} z1 Factor
- * @param {JXG.Complex,Number} z2 Factor
+ * @param {JXG.Complex|Number} z1 Factor
+ * @param {JXG.Complex|Number} z2 Factor
  * @returns {JXG.Complex} A complex number equal to the product of the given parameters.
  */
 JXG.C.mult = function (z1, z2) {
@@ -266,8 +266,8 @@ JXG.C.mult = function (z1, z2) {
 
 /**
  * Divide two (complex) numbers z1 and z2 and return the result as a (complex) number.
- * @param {JXG.Complex,Number} z1 Dividend
- * @param {JXG.Complex,Number} z2 Divisor
+ * @param {JXG.Complex|Number} z1 Dividend
+ * @param {JXG.Complex|Number} z2 Divisor
  * @returns {JXG.Complex} A complex number equal to the quotient of the given parameters.
  */
 JXG.C.div = function (z1, z2) {
@@ -278,7 +278,7 @@ JXG.C.div = function (z1, z2) {
 
 /**
  * Conjugate a complex number and return the result.
- * @param {JXG.Complex,Number} z1 Complex number
+ * @param {JXG.Complex|Number} z1 Complex number
  * @returns {JXG.Complex} A complex number equal to the conjugate of the given parameter.
  */
 JXG.C.conj = function (z1) {
@@ -289,7 +289,7 @@ JXG.C.conj = function (z1) {
 
 /**
  * Absolute value of a complex number.
- * @param {JXG.Complex,Number} z1 Complex number
+ * @param {JXG.Complex|Number} z1 Complex number
  * @returns {Number} real number equal to the absolute value of the given parameter.
  */
 JXG.C.abs = function (z1) {

--- a/src/math/geometry.js
+++ b/src/math/geometry.js
@@ -65,9 +65,9 @@ JXG.extend(
 
         /**
          * Calculates the angle defined by the points A, B, C.
-         * @param {JXG.Point,Array} A A point  or [x,y] array.
-         * @param {JXG.Point,Array} B Another point or [x,y] array.
-         * @param {JXG.Point,Array} C A circle - no, of course the third point or [x,y] array.
+         * @param {JXG.Point|Array} A A point  or [x,y] array.
+         * @param {JXG.Point|Array} B Another point or [x,y] array.
+         * @param {JXG.Point|Array} C A circle - no, of course the third point or [x,y] array.
          * @deprecated Use {@link JXG.Math.Geometry.rad} instead.
          * @see #rad
          * @see #trueAngle
@@ -117,9 +117,9 @@ JXG.extend(
 
         /**
          * Calculates the angle defined by the three points A, B, C if you're going from A to C around B counterclockwise.
-         * @param {JXG.Point,Array} A Point or [x,y] array
-         * @param {JXG.Point,Array} B Point or [x,y] array
-         * @param {JXG.Point,Array} C Point or [x,y] array
+         * @param {JXG.Point|Array} A Point or [x,y] array
+         * @param {JXG.Point|Array} B Point or [x,y] array
+         * @param {JXG.Point|Array} C Point or [x,y] array
          * @see #rad
          * @returns {Number} The angle in degrees.
          */
@@ -129,9 +129,9 @@ JXG.extend(
 
         /**
          * Calculates the internal angle defined by the three points A, B, C if you're going from A to C around B counterclockwise.
-         * @param {JXG.Point,Array} A Point or [x,y] array
-         * @param {JXG.Point,Array} B Point or [x,y] array
-         * @param {JXG.Point,Array} C Point or [x,y] array
+         * @param {JXG.Point|Array} A Point or [x,y] array
+         * @param {JXG.Point|Array} B Point or [x,y] array
+         * @param {JXG.Point|Array} C Point or [x,y] array
          * @see #trueAngle
          * @returns {Number} Angle in radians.
          */
@@ -1885,8 +1885,8 @@ JXG.extend(
          * If higher precision is needed, {@link JXG.Math.Geometry.meetCurveLineContinuous}
          * has to be used.
          *
-         * @param {JXG.Curve,JXG.Line} el1 Curve or Line
-         * @param {JXG.Curve,JXG.Line} el2 Curve or Line
+         * @param {JXG.Curve|JXG.Line} el1 Curve or Line
+         * @param {JXG.Curve|JXG.Line} el2 Curve or Line
          * @param {Number|Function} nr the nr-th intersection point will be returned.
          * @param {JXG.Board} [board=el1.board] Reference to a board object.
          * @param {Boolean} alwaysIntersect If false just the segment between the two defining points are tested for intersection
@@ -2835,7 +2835,7 @@ JXG.extend(
          * Calculates the coordinates of the projection of a given point on a given circle. I.o.w. the
          * nearest one of the two intersection points of the line through the given point and the circles
          * center.
-         * @param {JXG.Point,JXG.Coords} point Point to project or coords object to project.
+         * @param {JXG.Point|JXG.Coords} point Point to project or coords object to project.
          * @param {JXG.Circle} circle Circle on that the point is projected.
          * @param {JXG.Board} [board=point.board] Reference to the board
          * @returns {JXG.Coords} The coordinates of the projection of the given point on the given circle.

--- a/src/math/math.js
+++ b/src/math/math.js
@@ -740,7 +740,7 @@ JXG.Math = {
      *
      * @function
      * @param  {Number} x A Number
-     * @returns {[type]}  This function has 5 kinds of return values,
+     * @returns {Number}  This function has 5 kinds of return values,
      *    1, -1, 0, -0, NaN, which represent "positive number", "negative number", "positive zero", "negative zero"
      *    and NaN respectively.
      */

--- a/src/math/numerics.js
+++ b/src/math/numerics.js
@@ -187,16 +187,16 @@ Mat.Numerics = {
 
     /**
      * @private
-     * Gauss-Bareiss algorithm to compute the
-     * determinant of matrix without fractions.
-     * See Henri Cohen, "A Course in Computational
-     * Algebraic Number Theory (Graduate texts
-     * in mathematics; 138)", Springer-Verlag,
-     * ISBN 3-540-55640-0 / 0-387-55640-0
-     * Third, Corrected Printing 1996
-     * "Algorithm 2.2.6", pg. 52-53
      * @memberof JXG.Math.Numerics
      */
+    //  Gauss-Bareiss algorithm to compute the
+    //  determinant of matrix without fractions.
+    //  See Henri Cohen, "A Course in Computational
+    //  Algebraic Number Theory (Graduate texts
+    //  in mathematics; 138)", Springer-Verlag,
+    //  ISBN 3-540-55640-0 / 0-387-55640-0
+    //  Third, Corrected Printing 1996
+    //  "Algorithm 2.2.6", pg. 52-53
     gaussBareiss: function (mat) {
         var k,
             c,
@@ -1832,12 +1832,12 @@ Mat.Numerics = {
 
     /**
      * Evaluate points on spline.
-     * @param {Number,Array} x0 A single float value or an array of values to evaluate
+     * @param {Number|Array} x0 A single float value or an array of values to evaluate
      * @param {Array} x x values of knots
      * @param {Array} y y values of knots
      * @param {Array} F Second derivatives at knots, calculated by {@link JXG.Math.Numerics.splineDef}
      * @see #splineDef
-     * @returns {Number,Array} A single value or an array, depending on what is given as x0.
+     * @returns {Number|Array} A single value or an array, depending on what is given as x0.
      * @memberof JXG.Math.Numerics
      */
     splineEval: function (x0, x, y, F) {
@@ -2514,7 +2514,7 @@ Mat.Numerics = {
     /**
      * Computes the regression polynomial of a given degree through a given set of coordinates.
      * Returns the regression polynomial function.
-     * @param {Number,function,Slider} degree number, function or slider.
+     * @param {Number|function|Slider} degree number, function or slider.
      * Either
      * @param {Array} dataX Array containing either the x-coordinates of the data set or both coordinates in
      * an array of {@link JXG.Point}s or {@link JXG.Coords}.
@@ -2967,7 +2967,7 @@ Mat.Numerics = {
      * is replaced by a parabola or a secant. IN case of "simpson",
      * the parabola is approximated visually by a polygonal chain of fixed step width.
      *
-     * @param {Function,Array} f Function or array of two functions.
+     * @param {Function|Array} f Function or array of two functions.
      * If f is a function the integral of this function is approximated by the Riemann sum.
      * If f is an array consisting of two functions the area between the two functions is filled
      * by the Riemann sum bars.
@@ -3126,7 +3126,7 @@ Mat.Numerics = {
     /**
      * Solve initial value problems numerically using <i>explicit</i> Runge-Kutta methods.
      * See {@link https://en.wikipedia.org/wiki/Runge-Kutta_methods} for more information on the algorithm.
-     * @param {object,String} butcher Butcher tableau describing the Runge-Kutta method to use. This can be either a string describing
+     * @param {object|String} butcher Butcher tableau describing the Runge-Kutta method to use. This can be either a string describing
      * a Runge-Kutta method with a Butcher tableau predefined in JSXGraph like 'euler', 'heun', 'rk4' or an object providing the structure
      * <pre>
      * {
@@ -3358,7 +3358,7 @@ Mat.Numerics = {
      *
      * Find zero of an univariate function f.
      * @param {function} f Function, whose root is to be found
-     * @param {Array,Number} x0  Start value or start interval enclosing the root
+     * @param {Array|Number} x0  Start value or start interval enclosing the root
      * @param {Object} object Parent object in case f is method of it
      * @returns {Number} the approximation of the root
      * Algorithm:
@@ -3533,7 +3533,7 @@ Mat.Numerics = {
     /**
      * Find zero of an univariate function f.
      * @param {function} f Function, whose root is to be found
-     * @param {Array,Number} x0  Start value or start interval enclosing the root
+     * @param {Array|Number} x0  Start value or start interval enclosing the root
      * @param {Object} object Parent object in case f is method of it
      * @returns {Number} the approximation of the root
      * Algorithm:

--- a/src/options.js
+++ b/src/options.js
@@ -295,7 +295,8 @@ JXG.Options = {
          * Supply the document object. Defaults to window.document
          *
          * @name JXG.Board#document
-         * @type DOM object
+         * @type Object
+         * @description DOM object
          * @default false (meaning window.document)
          */
         document: false,
@@ -818,7 +819,8 @@ JXG.Options = {
          * board.addEventHandlers();
          *
          * @name JXG.Board#moveTarget
-         * @type HTML node or document
+         * @type Object
+         * @description HTML node or document
          * @default null
          *
          * @example
@@ -2157,8 +2159,8 @@ JXG.Options = {
          * @name JXG.GeometryElement#isLabel
          * @default false
          * @private
-         * By default, an element is not a label. Do not change this.
-         */
+        */
+        // By default, an element is not a label. Do not change this.
         isLabel: false,
 
         /**
@@ -4259,7 +4261,7 @@ JXG.Options = {
          * Recommended arrow head type is 7.
          *
          * @name Curve#firstArrow
-         * @type Boolean / Object
+         * @type Boolean | Object
          * @default false
          * @see Line#firstArrow for options
          */
@@ -4271,7 +4273,7 @@ JXG.Options = {
          *
          * @name Curve#lastArrow
          * @see Line#lastArrow for options
-         * @type Boolean / Object
+         * @type Boolean | Object
          * @default false
          */
         lastArrow: false
@@ -4980,7 +4982,7 @@ JXG.Options = {
          * @name Line#firstArrow
          * @see Line#lastArrow
          * @see Line#touchFirstPoint
-         * @type Boolean / Object
+         * @type Boolean | Object
          * @default false
          */
         firstArrow: false,
@@ -5074,7 +5076,7 @@ JXG.Options = {
          * @name Line#lastArrow
          * @see Line#firstArrow
          * @see Line#touchLastPoint
-         * @type Boolean / Object
+         * @type Boolean | Object
          * @default false
          */
         lastArrow: false,
@@ -5591,7 +5593,8 @@ JXG.Options = {
          *
          * @name Point#showInfobox
          * @see JXG.Board#showInfobox
-         * @type {Boolean|String} true | false | 'inherit'
+         * @type Boolean|String
+         * @description true | false | 'inherit'
          * @default true
          */
         showInfobox: 'inherit',
@@ -5606,7 +5609,7 @@ JXG.Options = {
          *
          * @name Point#infoboxDigits
          *
-         * @type String, Number
+         * @type String| Number
          * @default 'auto'
          * @see JXG#autoDigits
          * @see JXG#toFixed

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -232,7 +232,7 @@ var simpleColors = {
  * Converts a valid HTML/CSS color string into a rgb value array. This is the base
  * function for the following wrapper functions which only adjust the output to
  * different flavors like an object, string or hex values.
- * @param {String,Array,Number} color A valid HTML or CSS styled color value, e.g. '#12ab21', '#abc', 'black',
+ * @param {String|Array|Number} color A valid HTML or CSS styled color value, e.g. '#12ab21', '#abc', 'black',
  * or 'rgb(12, 132, 233)'. This can also be an array containing three color values either from 0.0 to 1.0 or
  * from 0 to 255. They will be interpreted as red, green, and blue values. In case this is a number this method
  * expects the parameters ag and ab.
@@ -328,7 +328,7 @@ JXG.rgbParser = function (color, ag, ab) {
 
 /**
  * Converts a valid HTML/CSS color string into a string of the 'rgb(r, g, b)' format.
- * @param {String,Array,Number} color A valid HTML or CSS styled color value, e.g. '#12ab21', '#abc', 'black',
+ * @param {String|Array|Number} color A valid HTML or CSS styled color value, e.g. '#12ab21', '#abc', 'black',
  * or 'rgb(12, 132, 233)'. This can also be an array containing three color values either from 0.0 to 1.0 or
  * from 0 to 255. They will be interpreted as red, green, and blue values. In case this is a number this method
  * expects the parameters ag and ab.
@@ -346,7 +346,7 @@ JXG.rgb2css = function (color, ag, ab) {
 
 /**
  * Converts a valid HTML/CSS color string into a HTML rgb string.
- * @param {String,Array,Number} color A valid HTML or CSS styled color value, e.g. '#12ab21', '#abc', 'black',
+ * @param {String|Array|Number} color A valid HTML or CSS styled color value, e.g. '#12ab21', '#abc', 'black',
  * or 'rgb(12, 132, 233)'. This can also be an array containing three color values either from 0.0 to 1.0 or
  * from 0 to 255. They will be interpreted as red, green, and blue values. In case this is a number this method
  * expects the parameters ag and ab.
@@ -477,7 +477,7 @@ JXG.hsv2rgb = function (H, S, V) {
 
 /**
  * Converts a color from the RGB color space into the HSV space. Input can be any valid HTML/CSS color definition.
- * @param {String,Array,Number} color A valid HTML or CSS styled color value, e.g. '#12ab21', '#abc', 'black',
+ * @param {String|Array|Number} color A valid HTML or CSS styled color value, e.g. '#12ab21', '#abc', 'black',
  * or 'rgb(12, 132, 233)'. This can also be an array containing three color values either from 0.0 to 1.0 or
  * from 0 to 255. They will be interpreted as red, green, and blue values. In case this is a number this method
  * expects the parameters ag and ab.
@@ -536,7 +536,7 @@ JXG.rgb2hsv = function (color, ag, ab) {
 
 /**
  * Converts a color from the RGB color space into the LMS space. Input can be any valid HTML/CSS color definition.
- * @param {String,Array,Number} color A valid HTML or CSS styled color value, e.g. '#12ab21', '#abc', 'black',
+ * @param {String|Array|Number} color A valid HTML or CSS styled color value, e.g. '#12ab21', '#abc', 'black',
  * or 'rgb(12, 132, 233)'. This can also be an array containing three color values either from 0.0 to 1.0 or
  * from 0 to 255. They will be interpreted as red, green, and blue values. In case this is a number this method
  * expects the parameters ag and ab.


### PR DESCRIPTION
These are cosmetic changes to the documentation tags to make them compatible with current JsDoc validation.  

Roughly there are four kinds of changes in the PR   
- @type expects a definite and recognizable type, where necessary I moved the argument to a @description tag immediately below
- using or-bars instead of commas for alternative @param types
- no empty @description tags
-  @private methods are not permitted to have @descriptions.