### PR TITLE
add some measurement internas

### DIFF
--- a/src/base/element.js
+++ b/src/base/element.js
@@ -1584,6 +1584,18 @@ JXG.extend(
             if (!firstArrow && lastArrow) {
                 this.type = Const.OBJECT_TYPE_VECTOR;
                 this.elType = "arrow";
+
+                this.Direction = function () {
+                    var coords1 = this.point1.coords.usrCoords,
+                        coords2 = this.point2.coords.usrCoords;
+
+                    return [
+                        coords2[1] - coords1[1],
+                        coords2[2] - coords1[2]
+                    ];
+                };
+            } else {
+                this.Direction = undefined;
             }
 
             this.prepareUpdate().update().updateVisibility().updateRenderer();

--- a/src/base/element.js
+++ b/src/base/element.js
@@ -1581,7 +1581,7 @@ JXG.extend(
         setArrow: function (firstArrow, lastArrow) {
             this.visProp.firstarrow = firstArrow;
             this.visProp.lastarrow = lastArrow;
-            if (lastArrow) {
+            if (!firstArrow && lastArrow) {
                 this.type = Const.OBJECT_TYPE_VECTOR;
                 this.elType = "arrow";
             }

--- a/src/base/line.js
+++ b/src/base/line.js
@@ -429,9 +429,9 @@ JXG.extend(
                 this.isReal =
                     !isNaN(
                         this.point1.coords.usrCoords[1] +
-                            this.point1.coords.usrCoords[2] +
-                            this.point2.coords.usrCoords[1] +
-                            this.point2.coords.usrCoords[2]
+                        this.point1.coords.usrCoords[2] +
+                        this.point2.coords.usrCoords[1] +
+                        this.point2.coords.usrCoords[2]
                     ) && Mat.innerProduct(this.stdform, this.stdform, 3) >= Mat.eps * Mat.eps;
 
                 if (
@@ -902,7 +902,7 @@ JXG.extend(
          * @returns {JXG.Line} Reference to this line
          */
         setFixedLength: function (l) {
-            if(!this.hasFixedLength) {
+            if (!this.hasFixedLength) {
                 return this;
             }
 
@@ -1099,11 +1099,11 @@ JXG.createLine = function (board, parents, attributes) {
         } else {
             throw new Error(
                 "JSXGraph: Can't create line with parent types '" +
-                    typeof parents[0] +
-                    "' and '" +
-                    typeof parents[1] +
-                    "'." +
-                    "\nPossible parent types: [point,point], [[x1,y1],[x2,y2]], [a,b,c]"
+                typeof parents[0] +
+                "' and '" +
+                typeof parents[1] +
+                "'." +
+                "\nPossible parent types: [point,point], [[x1,y1],[x2,y2]], [a,b,c]"
             );
         }
 
@@ -1128,11 +1128,11 @@ JXG.createLine = function (board, parents, attributes) {
         } else {
             throw new Error(
                 "JSXGraph: Can't create line with parent types '" +
-                    typeof parents[0] +
-                    "' and '" +
-                    typeof parents[1] +
-                    "'." +
-                    "\nPossible parent types: [point,point], [[x1,y1],[x2,y2]], [a,b,c]"
+                typeof parents[0] +
+                "' and '" +
+                typeof parents[1] +
+                "'." +
+                "\nPossible parent types: [point,point], [[x1,y1],[x2,y2]], [a,b,c]"
             );
         }
 
@@ -1167,13 +1167,13 @@ JXG.createLine = function (board, parents, attributes) {
             } else {
                 throw new Error(
                     "JSXGraph: Can't create line with parent types '" +
-                        typeof parents[0] +
-                        "' and '" +
-                        typeof parents[1] +
-                        "' and '" +
-                        typeof parents[2] +
-                        "'." +
-                        "\nPossible parent types: [point,point], [[x1,y1],[x2,y2]], [a,b,c]"
+                    typeof parents[0] +
+                    "' and '" +
+                    typeof parents[1] +
+                    "' and '" +
+                    typeof parents[2] +
+                    "'." +
+                    "\nPossible parent types: [point,point], [[x1,y1],[x2,y2]], [a,b,c]"
                 );
             }
         }
@@ -1182,44 +1182,44 @@ JXG.createLine = function (board, parents, attributes) {
         attr = Type.copyAttributes(attributes, board.options, "line", "point1");
         if (isDraggable) {
             p1 = board.create("point", [
-                    c[2]() * c[2]() + c[1]() * c[1](),
-                    c[2]() - c[1]() * c[0]() + c[2](),
-                    -c[1]() - c[2]() * c[0]() - c[1]()
-                ], attr);
+                c[2]() * c[2]() + c[1]() * c[1](),
+                c[2]() - c[1]() * c[0]() + c[2](),
+                -c[1]() - c[2]() * c[0]() - c[1]()
+            ], attr);
         } else {
             p1 = board.create("point", [
-                    function () {
-                        return (c[2]() * c[2]() + c[1]() * c[1]()) * 0.5;
-                    },
-                    function () {
-                        return (c[2]() - c[1]() * c[0]() + c[2]()) * 0.5;
-                    },
-                    function () {
-                        return (-c[1]() - c[2]() * c[0]() - c[1]()) * 0.5;
-                    }
-                ], attr);
+                function () {
+                    return (c[2]() * c[2]() + c[1]() * c[1]()) * 0.5;
+                },
+                function () {
+                    return (c[2]() - c[1]() * c[0]() + c[2]()) * 0.5;
+                },
+                function () {
+                    return (-c[1]() - c[2]() * c[0]() - c[1]()) * 0.5;
+                }
+            ], attr);
         }
 
         // point 2: (b^2+c^2,-ba+c,-ca-b)
         attr = Type.copyAttributes(attributes, board.options, "line", "point2");
         if (isDraggable) {
             p2 = board.create("point", [
-                    c[2]() * c[2]() + c[1]() * c[1](),
-                    -c[1]() * c[0]() + c[2](),
-                    -c[2]() * c[0]() - c[1]()
-                ], attr);
+                c[2]() * c[2]() + c[1]() * c[1](),
+                -c[1]() * c[0]() + c[2](),
+                -c[2]() * c[0]() - c[1]()
+            ], attr);
         } else {
             p2 = board.create("point", [
-                    function () {
-                        return c[2]() * c[2]() + c[1]() * c[1]();
-                    },
-                    function () {
-                        return -c[1]() * c[0]() + c[2]();
-                    },
-                    function () {
-                        return -c[2]() * c[0]() - c[1]();
-                    }
-                ], attr);
+                function () {
+                    return c[2]() * c[2]() + c[1]() * c[1]();
+                },
+                function () {
+                    return -c[1]() * c[0]() + c[2]();
+                },
+                function () {
+                    return -c[2]() * c[0]() - c[1]();
+                }
+            ], attr);
         }
 
         // If the line will have a glider and board.suspendUpdate() has been called, we
@@ -1258,29 +1258,29 @@ JXG.createLine = function (board, parents, attributes) {
 
         attr = Type.copyAttributes(attributes, board.options, "line", "point1");
         p1 = board.create("point", [
-                function () {
-                    var c = ps();
+            function () {
+                var c = ps();
 
-                    return [
-                        (c[2] * c[2] + c[1] * c[1]) * 0.5,
-                        (c[2] - c[1] * c[0] + c[2]) * 0.5,
-                        (-c[1] - c[2] * c[0] - c[1]) * 0.5
-                    ];
-                }
-            ], attr);
+                return [
+                    (c[2] * c[2] + c[1] * c[1]) * 0.5,
+                    (c[2] - c[1] * c[0] + c[2]) * 0.5,
+                    (-c[1] - c[2] * c[0] - c[1]) * 0.5
+                ];
+            }
+        ], attr);
 
         attr = Type.copyAttributes(attributes, board.options, "line", "point2");
         p2 = board.create("point", [
-                function () {
-                    var c = ps();
+            function () {
+                var c = ps();
 
-                    return [
-                        c[2] * c[2] + c[1] * c[1],
-                        -c[1] * c[0] + c[2],
-                        -c[2] * c[0] - c[1]
-                    ];
-                }
-            ], attr);
+                return [
+                    c[2] * c[2] + c[1] * c[1],
+                    -c[1] * c[0] + c[2],
+                    -c[2] * c[0] - c[1]
+                ];
+            }
+        ], attr);
 
         attr = Type.copyAttributes(attributes, board.options, "line");
         el = new JXG.Line(board, p1, p2, attr);
@@ -1291,11 +1291,11 @@ JXG.createLine = function (board, parents, attributes) {
     } else {
         throw new Error(
             "JSXGraph: Can't create line with parent types '" +
-                typeof parents[0] +
-                "' and '" +
-                typeof parents[1] +
-                "'." +
-                "\nPossible parent types: [point,point], [[x1,y1],[x2,y2]], [a,b,c]"
+            typeof parents[0] +
+            "' and '" +
+            typeof parents[1] +
+            "'." +
+            "\nPossible parent types: [point,point], [[x1,y1],[x2,y2]], [a,b,c]"
         );
     }
 
@@ -1385,9 +1385,9 @@ JXG.createSegment = function (board, parents, attributes) {
         } else {
             throw new Error(
                 "JSXGraph: Can't create segment with third parent type '" +
-                    typeof parents[2] +
-                    "'." +
-                    "\nPossible third parent types: number or function"
+                typeof parents[2] +
+                "'." +
+                "\nPossible third parent types: number or function"
             );
         }
 
@@ -1453,6 +1453,22 @@ JXG.createArrow = function (board, parents, attributes) {
     //el.setArrow(false, true);
     el.type = Const.OBJECT_TYPE_VECTOR;
     el.elType = "arrow";
+
+    /**
+     * Returns the direction vector of the arrow.
+     * @name Direction
+     * @function
+     * @returns {Array} direction vector as [x, y] of the arrow.
+     */
+    el.Direction = function () {
+        var coords1 = this.point1.coords.usrCoords,
+            coords2 = this.point2.coords.usrCoords;
+
+        return [
+            coords2[1] - coords1[1],
+            coords2[2] - coords1[2]
+        ];
+    };
 
     return el;
 };
@@ -1606,21 +1622,21 @@ JXG.createTangent = function (board, parents, attributes) {
         } else {
             throw new Error(
                 "JSXGraph: Can't create tangent with parent types '" +
-                    typeof parents[0] +
-                    "' and '" +
-                    typeof parents[1] +
-                    "'." +
-                    "\nPossible parent types: [glider], [point,line|curve|circle|conic]"
-            );
-        }
-    } else {
-        throw new Error(
-            "JSXGraph: Can't create tangent with parent types '" +
                 typeof parents[0] +
                 "' and '" +
                 typeof parents[1] +
                 "'." +
                 "\nPossible parent types: [glider], [point,line|curve|circle|conic]"
+            );
+        }
+    } else {
+        throw new Error(
+            "JSXGraph: Can't create tangent with parent types '" +
+            typeof parents[0] +
+            "' and '" +
+            typeof parents[1] +
+            "'." +
+            "\nPossible parent types: [glider], [point,line|curve|circle|conic]"
         );
     }
 
@@ -1745,13 +1761,13 @@ JXG.createTangent = function (board, parents, attributes) {
             tangent = board.create(
                 "line",
                 [
-                    function() {
+                    function () {
                         return getCurveTangentDir(p.position, c, 0);
                     },
-                    function() {
+                    function () {
                         return getCurveTangentDir(p.position, c, 1);
                     },
-                    function() {
+                    function () {
                         return getCurveTangentDir(p.position, c, 2);
                     }
                 ],
@@ -1931,11 +1947,11 @@ JXG.createRadicalAxis = function (board, parents, attributes) {
         // Failure
         throw new Error(
             "JSXGraph: Can't create 'radical axis' with parent types '" +
-                typeof parents[0] +
-                "' and '" +
-                typeof parents[1] +
-                "'." +
-                "\nPossible parent type: [circle,circle]"
+            typeof parents[0] +
+            "' and '" +
+            typeof parents[1] +
+            "'." +
+            "\nPossible parent type: [circle,circle]"
         );
     }
 
@@ -2051,11 +2067,11 @@ JXG.createPolarLine = function (board, parents, attributes) {
         // Failure
         throw new Error(
             "JSXGraph: Can't create 'polar line' with parent types '" +
-                typeof parents[0] +
-                "' and '" +
-                typeof parents[1] +
-                "'." +
-                "\nPossible parent type: [conic|circle,point], [point,conic|circle]"
+            typeof parents[0] +
+            "' and '" +
+            typeof parents[1] +
+            "'." +
+            "\nPossible parent type: [conic|circle,point], [point,conic|circle]"
         );
     }
 

--- a/src/element/composition.js
+++ b/src/element/composition.js
@@ -1094,6 +1094,22 @@ JXG.createArrowParallel = function (board, parents, attributes) {
 
         // parents are set in createParallel
 
+        /**
+         * Returns the direction vector of the arrow.
+         * @name Direction
+         * @function
+         * @returns {Array} direction vector as [x, y] of the arrow.
+         */
+        p.Direction = function () {
+            var coords1 = this.point1.coords.usrCoords,
+                coords2 = this.point2.coords.usrCoords;
+
+            return [
+                coords2[1] - coords1[1],
+                coords2[2] - coords1[2]
+            ];
+        };
+
         return p;
     } catch (e) {
         throw new Error(

--- a/src/element/composition.js
+++ b/src/element/composition.js
@@ -1089,6 +1089,7 @@ JXG.createArrowParallel = function (board, parents, attributes) {
             straightFirst: false,
             straightLast: false
         });
+        p.type = Const.OBJECT_TYPE_VECTOR;
         p.elType = "arrowparallel";
 
         // parents are set in createParallel

--- a/src/element/measure.js
+++ b/src/element/measure.js
@@ -339,6 +339,28 @@ JXG.createMeasurement = function (board, parents, attributes) {
         }
         return Prefix.dimension(term);
     };
+    el.Unit = function () {
+        let unit = '',
+            units = Type.evaluate(el.visProp.units),
+            dim = el.Dimension();
+
+        if (Type.isObject(units) && Type.exists(units[dim]) && units[dim] !== false) {
+            unit = Type.evaluate(units[dim]);
+        } else if (Type.isObject(units) && Type.exists(units['dim' + dim]) && units['dim' + dim] !== false) {
+            // In some cases, object keys must not be numbers. This allows key 'dim1' instead of '1'.
+            unit = Type.evaluate(units['dim' + dim]);
+        } else {
+            unit = Type.evaluate(el.visProp.baseunit);
+
+            if (dim === 0) {
+                unit = '';
+            } else if (dim > 1 && unit !== '') {
+                unit = unit + '^{' + dim + '}';
+            }
+        }
+
+        return unit;
+    };
     el.toInfix = function (type) {
         return Prefix.toInfix(term, type);
     };
@@ -362,10 +384,8 @@ JXG.createMeasurement = function (board, parents, attributes) {
             suffix = '',
             dim = el.Dimension(),
             digits = Type.evaluate(el.visProp.digits),
-            unit = '',
-            units = Type.evaluate(el.visProp.units),
+            unit = el.Unit(),
             val = el.Value(),
-            valArr,
             pattern = '',
             i;
 
@@ -444,21 +464,6 @@ JXG.createMeasurement = function (board, parents, attributes) {
 
         if (isNaN(dim)) {
             return prefix + 'NaN' + suffix;
-        }
-
-        if (Type.isObject(units) && Type.exists(units[dim]) && units[dim] !== false) {
-            unit = Type.evaluate(units[dim]);
-        } else if (Type.isObject(units) && Type.exists(units['dim' + dim]) && units['dim' + dim] !== false) {
-            // In some cases, object keys must not be numbers. This allows key 'dim1' instead of '1'.
-            unit = Type.evaluate(units['dim' + dim]);
-        } else {
-            unit = Type.evaluate(el.visProp.baseunit);
-
-            if (dim === 0) {
-                unit = '';
-            } else if (dim > 1 && unit !== '') {
-                unit = unit + '^{' + dim + '}';
-            }
         }
 
         if (unit !== '') {

--- a/src/element/measure.js
+++ b/src/element/measure.js
@@ -365,8 +365,9 @@ JXG.createMeasurement = function (board, parents, attributes) {
             unit = '',
             units = Type.evaluate(el.visProp.units),
             val = el.Value(),
-            coordsPattern = '',
-            i, coords;
+            valArr,
+            pattern = '',
+            i;
 
         if (Type.isNumber(val)) {
             if (digits === 'none') {
@@ -408,24 +409,40 @@ JXG.createMeasurement = function (board, parents, attributes) {
         }
 
         if (dim === 'coords' && Type.isArray(val)) {
-            coordsPattern = Type.evaluate(el.visProp.coordspattern).split('');
+            pattern = Type.evaluate(el.visProp.coordspattern).split('');
 
             if (val.length === 2) {
                 val.unshift(undefined);
             }
-            coords = [];
-            for (i = 0; i < coordsPattern.length; i++) {
-                if (coordsPattern[i] === 'x') {
-                    coords.push(val[1]);
-                } else if (coordsPattern[i] === 'y') {
-                    coords.push(val[2]);
-                } else if (coordsPattern[i] === 'z') {
-                    coords.push(val[0]);
+            valArr = [];
+            for (i = 0; i < pattern.length; i++) {
+                if (pattern[i] === 'x') {
+                    valArr.push(val[1]);
+                } else if (pattern[i] === 'y') {
+                    valArr.push(val[2]);
+                } else if (pattern[i] === 'z') {
+                    valArr.push(val[0]);
                 } else {
-                    coords.push(coordsPattern[i]);
+                    valArr.push(pattern[i]);
                 }
             }
-            val = coords.join('');
+            val = valArr.join('');
+        }
+
+        if (dim === 'direction' && Type.isArray(val)) {
+            pattern = Type.evaluate(el.visProp.directionpattern).split('');
+
+            valArr = [];
+            for (i = 0; i < pattern.length; i++) {
+                if (pattern[i] === 'x') {
+                    valArr.push(val[0]);
+                } else if (pattern[i] === 'y') {
+                    valArr.push(val[1]);
+                } else {
+                    valArr.push(pattern[i]);
+                }
+            }
+            val = valArr.join('');
         }
 
         if (Type.evaluate(el.visProp.showprefix)) {

--- a/src/element/measure.js
+++ b/src/element/measure.js
@@ -409,40 +409,26 @@ JXG.createMeasurement = function (board, parents, attributes) {
         }
 
         if (dim === 'coords' && Type.isArray(val)) {
-            pattern = Type.evaluate(el.visProp.coordspattern).split('');
+            pattern = Type.evaluate(el.visProp.coordspattern);
 
             if (val.length === 2) {
                 val.unshift(undefined);
             }
-            valArr = [];
-            for (i = 0; i < pattern.length; i++) {
-                if (pattern[i] === 'x') {
-                    valArr.push(val[1]);
-                } else if (pattern[i] === 'y') {
-                    valArr.push(val[2]);
-                } else if (pattern[i] === 'z') {
-                    valArr.push(val[0]);
-                } else {
-                    valArr.push(pattern[i]);
-                }
-            }
-            val = valArr.join('');
+
+            pattern = pattern.replace(/%x%/g, val[1]);
+            pattern = pattern.replace(/%y%/g, val[2]);
+            pattern = pattern.replace(/%z%/g, val[0]);
+
+            val = pattern;
         }
 
         if (dim === 'direction' && Type.isArray(val)) {
-            pattern = Type.evaluate(el.visProp.directionpattern).split('');
+            pattern = Type.evaluate(el.visProp.directionpattern);
 
-            valArr = [];
-            for (i = 0; i < pattern.length; i++) {
-                if (pattern[i] === 'x') {
-                    valArr.push(val[0]);
-                } else if (pattern[i] === 'y') {
-                    valArr.push(val[1]);
-                } else {
-                    valArr.push(pattern[i]);
-                }
-            }
-            val = valArr.join('');
+            pattern = pattern.replace(/%x%/g, val[0]);
+            pattern = pattern.replace(/%y%/g, val[1]);
+
+            val = pattern;
         }
 
         if (Type.evaluate(el.visProp.showprefix)) {

--- a/src/element/measure.js
+++ b/src/element/measure.js
@@ -365,7 +365,7 @@ JXG.createMeasurement = function (board, parents, attributes) {
             unit = '',
             units = Type.evaluate(el.visProp.units),
             val = el.Value(),
-            coordsPattern='',
+            coordsPattern = '',
             i, coords;
 
         if (Type.isNumber(val)) {
@@ -384,9 +384,9 @@ JXG.createMeasurement = function (board, parents, attributes) {
                     val = Type.toFixed(val, digits);
                 }
             }
-        } else if(Type.isArray(val)) {
-            for (i = 0; i<val.length;i++) {
-                if(!Type.isNumber(val[i])){
+        } else if (Type.isArray(val)) {
+            for (i = 0; i < val.length; i++) {
+                if (!Type.isNumber(val[i])) {
                     continue;
                 }
                 if (digits === 'none') {
@@ -422,7 +422,7 @@ JXG.createMeasurement = function (board, parents, attributes) {
                 } else if (coordsPattern[i] === 'z') {
                     coords.push(val[0]);
                 } else {
-                    coords.push(coordsPattern[i])
+                    coords.push(coordsPattern[i]);
                 }
             }
             val = coords.join('');
@@ -443,9 +443,9 @@ JXG.createMeasurement = function (board, parents, attributes) {
             return prefix + 'NaN' + suffix;
         }
 
-        if (Type.isObject(units) && Type.exists(units[dim])) {
+        if (Type.isObject(units) && Type.exists(units[dim]) && units[dim] !== false) {
             unit = Type.evaluate(units[dim]);
-        } else if (Type.isObject(units) && Type.exists(units['dim' + dim])) {
+        } else if (Type.isObject(units) && Type.exists(units['dim' + dim]) && units['dim' + dim] !== false) {
             // In some cases, object keys must not be numbers. This allows key 'dim1' instead of '1'.
             unit = Type.evaluate(units['dim' + dim]);
         } else {

--- a/src/options.js
+++ b/src/options.js
@@ -5615,7 +5615,8 @@ JXG.Options = {
         prefix: '',
         suffix: '',
 
-        coordsPattern: '(x,y)'
+        coordsPattern: '(x, y)',
+        directionPattern: '(x, y)'
 
         /**#@-*/
     },

--- a/src/options.js
+++ b/src/options.js
@@ -5608,11 +5608,14 @@ JXG.Options = {
         baseUnit: '',
         units: {},
         dim: null,
+
+        showPrefix: true,
+        showSuffix: true,
+
         prefix: '',
         suffix: '',
 
-        showPrefix: true,
-        showSuffix: true
+        coordsPattern: '(x,y)'
 
         /**#@-*/
     },

--- a/src/options.js
+++ b/src/options.js
@@ -5615,8 +5615,8 @@ JXG.Options = {
         prefix: '',
         suffix: '',
 
-        coordsPattern: '(x, y)',
-        directionPattern: '(x, y)'
+        coordsPattern: '(%x%, %y%)',
+        directionPattern: '(%x%, %y%)'
 
         /**#@-*/
     },


### PR DESCRIPTION
This PR

- adds an suggestion to measure point coordinates by `board.create('measurement', [0, 0, ['Coords', point)]], {dim: 'coords'})`
- allows to set `Options.measurement.units[1] = false` to force using baseUnit
- improves function `setArrow` by checking if firstArrow is false before changing object type (*but how will this be undone?*)
- changes the type of arrowparallel to `JXG.OBJECT_TYPE_VECOR` just like arrow
- adds an function direction to arrow and arrowparallel
- adds an suggestion to measure point coordinates by `board.create('measurement', [0, 0, ['Direction', vector)]], {dim: 'Direction'})`

It would be very nice if you could check these changes and let me know what can and cannot be taken over.

Thanks!