### PR TITLE
Add 3D intersection line element

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ Build and develop JSXGraph
 --------------
 
 1) Clone this repository or download the zip file.
-2) In order to build and develop *JSXGraph* you need [node.js](https://nodejs.org/) v0.6+. First, install all
+2) To build and develop *JSXGraph* you need [node.js](https://nodejs.org/) v0.6+. First, install all
 dependencies required to build JSXGraph using npm in the JSXGraph root directory: `$ npm install`.
 This will create a new subdirectory ```node_modules``` in the JSXGraph root directory which holds
 all tools and libraries required to build ```jsxgraphcore.js```.
-3) To build JSXGraph run `$ npm run buildCore`. This will output an unminified version `jsxgraphsrc.js`
+3) To build JSXGraph run `$ npm run buildCore`. This will output an non-minified version `jsxgraphsrc.js`
 and the minified version `jsxgraphcore.js` into the folder `distrib`.
 4) Develop JSXGraph:
   - Edit the source files in the folder `src`

--- a/examples/intersection_line.html
+++ b/examples/intersection_line.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>Board events</title>
+    <title>Intersection line</title>
     <link rel="stylesheet" type="text/css" href="../distrib/jsxgraph.css" />
     <script type="text/javascript" src="../distrib/jsxgraphcore.js"></script>
 </head>

--- a/examples/intersection_line.html
+++ b/examples/intersection_line.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Board events</title>
+    <link rel="stylesheet" type="text/css" href="../distrib/jsxgraph.css" />
+    <script type="text/javascript" src="../distrib/jsxgraphcore.js"></script>
+</head>
+<body>
+
+<div id="jxgbox" class="jxgbox" style="width:800px; height:800px; float:left"></div>
+
+<script type="text/javascript">
+    let board = JXG.JSXGraph.initBoard(
+        'jxgbox',
+        {
+            boundingbox: [-8, 8, 8,-8],
+            axis: false,
+            showcopyright: false,
+            shownavigation: false
+        }
+    );
+    let view = board.create(
+        'view3d',
+        [[-6, -3], [8, 8],
+        [[0, 3], [0, 3], [0, 3]]],
+        {
+            xPlaneRear: {fillOpacity: 0.2, gradient: null},
+            yPlaneRear: {fillOpacity: 0.2, gradient: null},
+            zPlaneRear: {fillOpacity: 0.2, gradient: null}
+        }
+    );
+
+    // Two planes
+    let basePt = view.create(
+        'point3d',
+        [1, 1, 1],
+        {
+            withLabel: false,
+            size: 5,
+            strokeWidth: 1,
+            strokeColor: '#600030',
+            fillColor: 'white',
+            gradient: 'radial',
+            gradientSecondColor: '#a00050',
+            gradientFX: 0.7,
+            gradientFY: 0.3,
+            highlightStrokeColor: '#600030'
+       }
+    );
+    let p1 = view.create(
+        'plane3d',
+        [basePt, [1, 0, 0], [0, 1, 0]],
+        {
+            strokeWidth: 1,
+            strokeColor: '#0000ff',
+            strokeOpacity: 0.5,
+            fillColor: '#0000ff',
+            fillOpacity: 0.1,
+            gradient: null
+        }
+    );
+    let p2 = view.create(
+        'plane3d',
+        [basePt, [-2, 1, 1], [1, -2, 1]],
+        {
+            strokeWidth: 1,
+            strokeColor: '#00ff80',
+            strokeOpacity: 0.5,
+            fillColor: '#00ff80',
+            fillOpacity: 0.1,
+            gradient: null
+        }
+    );
+
+    // The line where the two planes intersect
+    view.create(
+        'intersectionline3d',
+        [p1, p2],
+        {
+            strokeOpacity: 0.5,
+            highlightStrokeColor: 'black',
+            highlightStrokeOpacity: 0.5
+        }
+    );
+</script>
+</body>
+</html>

--- a/src/3d/linspace3d.js
+++ b/src/3d/linspace3d.js
@@ -723,4 +723,69 @@ JXG.createPlane3D = function (board, parents, attributes) {
 
     return el;
 };
+
+/**
+ * @class An intersection line is a line which lives on two JSXGraph elements.
+ * The following element types can be (mutually) intersected: plane.
+ *
+ * @pseudo
+ * @name IntersectionLine3D
+ * @augments JXG.Point
+ * @constructor
+ * @type JXG.Point
+ * @throws {Exception} If the element cannot be constructed with the given parent objects an exception is thrown.
+ * @param {JXG.Plane3D_JXG.Plane3D} el1,el2 The result will be the intersection point of el1 and el2.
+ * @example
+ * // Create the intersection line of two planes
+ * let a = view.create('point3d', [0, 0, 0]);
+ *
+ * let p1 = view.create(
+ *    'plane3d',
+ *     [a, [1, 0, 0], [0, 1, 0]],
+ *     {fillColor: '#00ff80'}
+ * );
+ * let p2 = view.create(
+ *    'plane3d',
+ *     [a, [1, 0, 0], [0, 0, 1]],
+ *     {fillColor: '#ff0000'}
+ * );
+ *
+ * let i = view.create('intersectionline3d', [p1, p2]);
+ */
+JXG.createIntersectionLine3D = function (board, parents, attributes) {
+    let view = parents[0],
+        el1 = parents[1],
+        el2 = parents[2],
+        ixnLine,
+        func,
+        attr = Type.copyAttributes(attributes, board.options, "intersection");
+
+    let pts = []
+    for (let i = 0; i < 2; i++) {
+        let func = Geometry.intersectionFunction3D(view, el1, el2, i);
+        pts[i] = view.create('point3d', func, {visible: false});
+    }
+    ixnLine = view.create('line3d', pts, attr);
+
+    try {
+        el1.addChild(ixnLine);
+        el2.addChild(ixnLine);
+    } catch (e) {
+        throw new Error(
+            "JSXGraph: Can't create 'intersection' with parent types '" +
+                typeof parents[0] +
+                "' and '" +
+                typeof parents[1] +
+                "'."
+        );
+    }
+
+    ixnLine.type = Const.OBJECT_TYPE_INTERSECTION_LINE3D;
+    ixnLine.elType = 'intersectionline';
+    ixnLine.setParents([el1.id, el2.id]);
+
+    return ixnLine;
+};
+
 JXG.registerElement('plane3d', JXG.createPlane3D);
+JXG.registerElement('intersectionline3d', JXG.createIntersectionLine3D);

--- a/src/base/constants.js
+++ b/src/base/constants.js
@@ -116,6 +116,8 @@ constants =
     OBJECT_TYPE_SURFACE3D: 37,
 
     OBJECT_TYPE_MEASUREMENT: 38,
+    
+    OBJECT_TYPE_INTERSECTION_LINE3D: 39,
 
     // IMPORTANT:
     // ----------

--- a/src/math/geometry.js
+++ b/src/math/geometry.js
@@ -1576,6 +1576,24 @@ JXG.extend(
         },
 
         /**
+         * Generate the function which computes the data of the intersection.
+         */
+        intersectionFunction3D: function (view, el1, el2, i) {
+            let func;
+            
+            if (
+                el1.type === Const.OBJECT_TYPE_PLANE3D &&
+                el2.type === Const.OBJECT_TYPE_PLANE3D
+            ) {
+                func = function () {
+                    return view.intersectionPlanePlane(el1, el2)[i];
+                };
+            }
+            
+            return func;
+        },
+
+        /**
          * Returns true if the coordinates are on the arc element,
          * false otherwise. Usually, coords is an intersection
          * on the circle line. Now it is decided if coords are on the

--- a/src/parser/jessiecode.js
+++ b/src/parser/jessiecode.js
@@ -2569,8 +2569,6 @@ JXG.extend(JXG.JessieCode.prototype, /** @lends JXG.JessieCode.prototype */ {
         this._addedBuiltIn[name].src = '$jc$.' + name;
 
         JXG.JessieCode.prototype[name] = func;
-
-        console.log('added', name, func)
     },
 
     /**

--- a/src/renderer/abstract.js
+++ b/src/renderer/abstract.js
@@ -1253,7 +1253,6 @@ JXG.extend(
                                 if (MathJax.typeset) {
                                     // Version 3
                                     MathJax.typeset([el.rendNode]);
-                                    console.log(el.id, el.rendNode);
                                 } else {
                                     // Version 2
                                     MathJax.Hub.Queue(["Typeset", MathJax.Hub, el.rendNode]);


### PR DESCRIPTION
### Summary

This adds an element representing a line of intersection in 3D space. It could use improvement, but it's a start, and it seems to work.

### Usage example

See `examples/intersection_line.html`.

### Implementation

- The element's behavior is governed by a new intersection function, `intersectionFunction3D`, which is modeled on the existing `intersectionFunction` governing intersection points in 2D space.
  - So far, the intersection function is only implemented for the intersection of two planes. In this case, it just wraps the existing `intersectionPlanePlane`, which is used to find bounding box intersections for rendering.
  - The implementation is a little wasteful: `intersectionPlanePlane` finds both intersection points, but it's used to find the intersection points one at a time, so the same computation gets done twice.
- It's registered as 'intersectionline3d', with creation function `JXG.createIntersectionLine3D`, in `linspace3d.js`.
- It has a new object type: `OBJECT_TYPE_INTERSECTION_LINE3D`.

### Loose ends

- The documentation is sketchy, and I haven't proofread it, because I can't figure out how to properly generate the project's JSDoc documentation.
- The implementation seems wasteful, as described above, and could use improvement.
- I haven't written any tests.