### PR TITLE
fix slider bug

### DIFF
--- a/src/element/slider.js
+++ b/src/element/slider.js
@@ -517,6 +517,7 @@ JXG.createSlider = function (board, parents, attributes) {
         t.dump = false;
     }
 
+    p3.type = Const.OBJECT_TYPE_SLIDER;
     p3.elType = "slider";
     p3.parents = parents;
     p3.subs = {

--- a/src/element/slider.js
+++ b/src/element/slider.js
@@ -235,7 +235,7 @@ JXG.createSlider = function (board, parents, attributes) {
     // attr = Type.copyAttributes(attributes, board.options, "slider");
     // overwrite this in any case; the sliders label is a special text element, not the gliders label.
     // this will be set back to true after the text was created (and only if withlabel was true initially).
-    attr.withLabel = false;
+    attr.withlabel = false;
     // gliders set snapwidth=-1 by default (i.e. deactivate them)
     p3 = board.create("glider", [startx, starty, l1], attr);
     p3.setAttribute({ snapwidth: snapWidth, snapvalues: snapValues, snapvaluedistance: snapValueDistance });


### PR DESCRIPTION
This small change causes the label at the slider point to no longer be displayed in sketchometry. The error is probably caused by the change in `copyAttributes`. Why it does not appear in normal JSXGraph-applets is a mystery to me.

Nevertheless, this fix makes sense: `attr` is created by `copyAttributes` and therefore all contained attributes are in lower case anyway (see e.g. initialization of `withText`).