### PR TITLE
Fix riemannsum string type

### DIFF
--- a/src/base/curve.js
+++ b/src/base/curve.js
@@ -2337,6 +2337,10 @@ JXG.createRiemannsum = function (board, parents, attributes) {
         );
     }
 
+    if (typeof parents[2] === 'string') {
+        parents[2] = '\'' + parents[2] + '\'';
+    }
+
     type = Type.createFunction(parents[2], board, "");
     if (!Type.exists(type)) {
         throw new Error(


### PR DESCRIPTION
This addresses issue #635  by adding escaped quotes to the string so that it gets processed as a string when converted to jessieCode.