### PR TITLE
Use push to concatenate single elements

### DIFF
--- a/src/3d/sphere3d.js
+++ b/src/3d/sphere3d.js
@@ -303,7 +303,7 @@ JXG.createSphere3D = function (board, parents, attributes) {
                     "JSXGraph: Can't create sphere3d from this type. Please provide a point type."
                 );
             }
-            Type.concat(p, provided);
+            p.push(provided);
         } else {
             p.push(parents[i]);
         }

--- a/src/3d/surface3d.js
+++ b/src/3d/surface3d.js
@@ -131,7 +131,9 @@ JXG.extend(
             } else {
                 func = [this.X, this.Y, this.Z];
             }
-            res = this.view.getMesh(func, Type.concat(r_u, [steps_u]), Type.concat(r_v, [steps_v]));
+            r_u.push(steps_u);
+            r_v.push(steps_v);
+            res = this.view.getMesh(func, r_u, r_v);
 
             return { X: res[0], Y: res[1] };
         },

--- a/src/base/circle.js
+++ b/src/base/circle.js
@@ -932,14 +932,14 @@ JXG.createCircle = function (board, parents, attributes) {
     for (i = 0; i < parents.length; i++) {
         if (Type.isPointType(board, parents[i])) {
             if (parents.length < 3) {
-                Type.concat(p,
-                    Type.providePoints(board, [parents[i]], attributes, "circle", [point_style[i]])
+                p.push(
+                    Type.providePoints(board, [parents[i]], attributes, "circle", [point_style[i]])[0]
                 );
             } else {
-                Type.concat(p,
-                    Type.providePoints(board, [parents[i]], attributes, "point")
+                p.push(
+                    Type.providePoints(board, [parents[i]], attributes, "point")[0]
                 );
-                }
+            }
             if (p[p.length - 1] === false) {
                 throw new Error(
                     "JSXGraph: Can't create circle from this type. Please provide a point type."


### PR DESCRIPTION
This pull request changes Sphere3D to address issue #641, and changes other elements similarly to streamline their code.

The function `Type.concat` is sometimes used to concatenate an array that clearly has only one element. Since `Type.concat` calls `push` repeatedly, we can streamline these usages by applying `push` directly to the single element. That's what this pull request does.

The function `Type.concat` was created as a faster replacement for `concat`. While `concat` can handle both arrays and single elements, `Type.concat` can only handle arrays. As a result, the Sphere3D constructor broke when `concat` was replaced with `Type.concat`, as described in issue #641. In this case, switching to `push` is necessary to fix the issue.