### PR TITLE
Support central projection for spheres

### DIFF
--- a/examples/intersection_sphere_sphere.html
+++ b/examples/intersection_sphere_sphere.html
@@ -8,6 +8,13 @@
 </head>
 <body>
 
+<div>
+    <label for="proj">Projection:</label>
+    <select id="proj" oninput="inputProjectionType();">
+        <option value="parallel">Parallel</option>
+        <option value="central">Central</option>
+    </select>
+</div>
 <div id="jxgbox" class="jxgbox" style="width:800px; height:800px; float:left"></div>
 
 <script type="text/javascript">
@@ -78,7 +85,7 @@
     
     // Two spheres
     let sphere1 = view.create(
-    'sphere3d',
+        'sphere3d',
         [center1, () => Math.pow(2, 0.5*balance.Value())],
         {
             strokeColor: '#0000ff',
@@ -92,7 +99,7 @@
         }
     );
     let sphere2 = view.create(
-    'sphere3d',
+        'sphere3d',
         [center2, () => Math.pow(2, -0.5*balance.Value())],
         {
             strokeColor: '#00ff80',
@@ -115,6 +122,13 @@
             strokeOpacity: 0.5
         }
     );
+
+    proj = document.querySelector('#proj');
+    function inputProjectionType() {
+        console.log(`--- ${proj.value} projection ---`);
+        view.setAttribute({'projection': proj.value});
+    }
+    inputProjectionType();
 </script>
 </body>
 </html>

--- a/examples/intersection_sphere_sphere.html
+++ b/examples/intersection_sphere_sphere.html
@@ -125,7 +125,6 @@
 
     proj = document.querySelector('#proj');
     function inputProjectionType() {
-        console.log(`--- ${proj.value} projection ---`);
         view.setAttribute({'projection': proj.value});
     }
     inputProjectionType();

--- a/src/3d/sphere3d.js
+++ b/src/3d/sphere3d.js
@@ -248,7 +248,7 @@ JXG.extend(
                     that.center.Y() + r * (sin_lean*inward[1] + cos_lean*cam[3][2]),
                     that.center.Z() + r * (sin_lean*inward[2] + cos_lean*cam[3][3])
                 ]);
-            }
+            };
         },
 
         buildCentralProjection: function () {
@@ -421,8 +421,6 @@ JXG.createSphere3D = function (board, parents, attributes) {
 
     var view = parents[0],
         attr, p, point_style, provided,
-        center2d, radius2d,
-        frontFocus, backFocus,
         el, i;
 
     attr = Type.copyAttributes(attributes, board.options, 'sphere3d');

--- a/src/3d/sphere3d.js
+++ b/src/3d/sphere3d.js
@@ -186,11 +186,14 @@ JXG.extend(
         // This factor method produces two functions, `focusFn(-1)` and
         // `focusFn(1)`, that evaluate to the projections of the front and back
         // points of the sphere, respectively.
-        focusFn: function (sgn) {
+        //
+        // [DEBUG] Using the optional argument, you can construct other extreme
+        // points for debugging.
+        focusFn: function (sgn, k = 2) {
             const that = this;
 
             return function () {
-                const camDir = that.view.cameraTransform[3];
+                const camDir = that.view.cameraTransform[k+1];
                 const r = that.Radius();
                 return view.project3DTo2D([
                     that.center.X() + sgn*r*camDir[1],
@@ -365,85 +368,25 @@ JXG.createSphere3D = function (board, parents, attributes) {
     }
 
     if (view.projectionType === 'central') {
-        let viewFrame = (k) => view.cameraTransform[k+1].slice(1, 4);
-        frontFocus = view.create(
-            'point',
-            el.focusFn(-1),
-            {
+        let debugAxisColors = ['orange', 'green', 'purple']; // [DEBUG]
+        let debugMarkerStyle = function (k) {
+            return {
                 size: 1,
-                fillColor: 'purple',
-                strokeColor: 'purple',
+                fillColor: debugAxisColors[k],
+                strokeColor: debugAxisColors[k],
                 withLabel: false
-            }
-        );
-        backFocus = view.create(
-            'point',
-            el.focusFn(1),
-            {
-                size: 1,
-                fillColor: 'purple',
-                strokeColor: 'purple',
-                withLabel: false
-            }
-        );
-        /*frontFocus = view.create(
-            'point',
-            function () {
-                const camDir = view.cameraTransform[2];
-                const r = el.Radius();
-                return view.project3DTo2D([
-                    el.center.X() + sgn*r*camDir[1],
-                    el.center.Y() + sgn*r*camDir[2],
-                    el.center.Z() + sgn*r*camDir[3]
-                ]).slice(1, 3)
-            },
-            {size: 1, fillColor: 'purple', strokeColor: 'purple', withLabel: false}
-        );
-        backFocus = view.create(
-            'point',
-            function () {
-                const out = viewFrame(2);
-                const r = el.Radius();
-                return view.project3DTo2D([
-                    el.center.X() + r*out[0],
-                    el.center.Y() + r*out[1],
-                    el.center.Z() + r*out[2]
-                ]).slice(1, 3)
-            },
-            {size: 1, fillColor: 'purple', strokeColor: 'purple', withLabel: false}
-        );*/
+            };
+        };
+        frontFocus = view.create('point', el.focusFn(-1), debugMarkerStyle(2));
+        backFocus = view.create('point', el.focusFn(1), debugMarkerStyle(2));
 
-        // show other view-space extremes, for debugging
-        const axisColors = ['orange', 'green'];
+        // [DEBUG] show other view-space extremes, for debugging
         for (let k = 0; k < 2; k++) {
-            view.create(
-                'point',
-                function () {
-                    const dir = viewFrame(k);
-                    const r = el.Radius();
-                    return view.project3DTo2D([
-                        el.center.X() - r*dir[0],
-                        el.center.Y() - r*dir[1],
-                        el.center.Z() - r*dir[2]
-                    ]).slice(1, 3)
-                },
-                {size: 1, fillColor: axisColors[k], strokeColor: axisColors[k], withLabel: false}
-            );
-            view.create(
-                'point',
-                function () {
-                    const dir = viewFrame(k);
-                    const r = el.Radius();
-                    return view.project3DTo2D([
-                        el.center.X() + r*dir[0],
-                        el.center.Y() + r*dir[1],
-                        el.center.Z() + r*dir[2]
-                    ]).slice(1, 3)
-                },
-                {size: 1, fillColor: axisColors[k], strokeColor: axisColors[k], withLabel: false}
-            );
+            view.create('point', el.focusFn(-1, k), debugMarkerStyle(k));
+            view.create('point', el.focusFn(1, k), debugMarkerStyle(k));
         }
 
+        let viewFrame = (k) => view.cameraTransform[k+1].slice(1, 4);
         const innerEdge = view.create(
             'point',
             function () {

--- a/src/3d/view3d.js
+++ b/src/3d/view3d.js
@@ -110,6 +110,9 @@ JXG.View3D = function (board, parents, attributes) {
      * The camera is actually set back from the screen by the focal distance. To
      * get actual view space vectors, with the focal distance accounted for, use
      * the `worldToView` method.
+     * 
+     * This transformation is exposed to help 3D elements manage their 2D
+     * representations in central projection mode.
      * @type {Array}
      */
     this.cameraTransform = [];

--- a/src/3d/view3d.js
+++ b/src/3d/view3d.js
@@ -105,7 +105,11 @@ JXG.View3D = function (board, parents, attributes) {
     ];
 
     /**
-     * The 4x4 matrix that maps world-space vectors to view-space vectors.
+     * The 4x4 matrix that maps world-space vectors to zero-focus view-space
+     * vectors---that is, view space vectors for a camera sitting on the screen.
+     * The camera is actually set back from the screen by the focal distance. To
+     * get actual view space vectors, with the focal distance accounted for, use
+     * the `worldToView` method.
      * @type {Array}
      */
     this.cameraTransform = [];
@@ -650,6 +654,26 @@ JXG.extend(
             this.board.removeObject(object, saveMethod);
 
             return this;
+        },
+
+        /**
+         * Map world coordinates to view coordinates.
+         *
+         * @param {Array} pWorld A world space point, in homogeneous coordinates.
+         * @param {Boolean} [homog=true] Whether to return homogeneous coordinates.
+         * If false, projects down to ordinary coordinates.
+         */
+        worldToView: function (pWorld, homog=true) {
+            var pView = Mat.matVecMult(this.cameraTransform, pWorld);
+            pView[3] -= pView[0] * this.focalDist;
+            if (homog) {
+                return pView;
+            } else {
+                for (let k = 1; k < 4; k++) {
+                    pView[k] /= pView[0];
+                }
+                return pView.slice(1, 4);
+            }
         },
 
         /**

--- a/src/3d/view3d.js
+++ b/src/3d/view3d.js
@@ -494,6 +494,10 @@ JXG.extend(
             ];
             A = Mat.matMatMult(A, Tcam1);
 
+            // expose camera transformation and field of view
+            this._Tcam1 = Tcam1;
+            this._foc = foc;
+
             return A;
         },
 

--- a/src/3d/view3d.js
+++ b/src/3d/view3d.js
@@ -110,7 +110,7 @@ JXG.View3D = function (board, parents, attributes) {
      * The camera is actually set back from the screen by the focal distance. To
      * get actual view space vectors, with the focal distance accounted for, use
      * the `worldToView` method.
-     * 
+     *
      * This transformation is exposed to help 3D elements manage their 2D
      * representations in central projection mode.
      * @type {Array}

--- a/src/element/conic.js
+++ b/src/element/conic.js
@@ -322,6 +322,7 @@ JXG.createEllipse = function (board, parents, attributes) {
         C.addChild(curve);
     }
     curve.setParents(parents);
+    console.log(`ellipse parents: ${curve.getParents()}`);
 
     return curve;
 };

--- a/src/element/conic.js
+++ b/src/element/conic.js
@@ -322,7 +322,6 @@ JXG.createEllipse = function (board, parents, attributes) {
         C.addChild(curve);
     }
     curve.setParents(parents);
-    console.log(`ellipse parents: ${curve.getParents()}`);
 
     return curve;
 };


### PR DESCRIPTION
This pull request makes `Sphere3D` elements render correctly in central projection mode. (Before, spheres were always rendered in parallel projection, ignoring the view's projection mode.)

#### Changes to `View3D`

To accomplish this, `View3D` is modified to expose:

- The camera transform
- The focal distance
- A method to convert world coordinates to view coordinates.

Each `Sphere3D` uses these to compute its central projection. The camera transform and focal distance are still computed when the view is updated, like before, but they're now saved as public attributes instead of being thrown away when the update finishes.

#### Switching projection modes

Unlike most elements, a `Sphere3D` represents itself with different 2D elements in different projection modes.

- The parallel projection of a sphere is a circle, represented as a `Circle` whose center and radius are determined by formulas.
- The central projection of a sphere is an ellipse, represented as an `Ellipse` deteremined by three `Point` elements—two at its foci, and one at a vertex.

The central projection involves more elements, and is costlier to compute, so it seems worthwhile to remove the central projection from the scene tree when the sphere is displaying in parallel projection.

Right now, a `Sphere3D` checks the projection mode of its view at each update. If the projection mode has changed, it removes its current `element2D` (and any supporting elements) from the board and throws away its references to them. Then it builds a new `element2D` for the new projection mode. It might be more efficient to keep both projections in the scene tree, and just disable updates for the one that's not being used, but I don't know of any way to do that.