### PR TITLE
Add 3D polygon element

### DIFF
--- a/examples/polygon3d.html
+++ b/examples/polygon3d.html
@@ -31,9 +31,9 @@
         }
     );
 
-    // Vertices
-    let vertices = [];
-    coords = [
+    // Vertices of first polygon
+    let vertices1 = [];
+    coords1 = [
         [2, 1, 1],
         [2, 2, 1],
         [1, 2, 1],
@@ -41,7 +41,7 @@
         [1, 1, 2],
         [1, 1, 1]
     ];
-    colors = [
+    colors1 = [
         'orangered',
         'gold',
         'mediumseagreen',
@@ -49,27 +49,66 @@
         'purple',
         'deeppink'
     ];
-    for (let i = 0; i < coords.length; i++) {
-        vertices.push(view.create(
+    for (i in coords1) {
+        vertices1.push(view.create(
             'point3d',
-            coords[i],
+            coords1[i],
             {
                 withLabel: false,
                 size: 5,
-                strokeWidth: 1,
-                strokeColor: colors[i],
+                strokeColor: 'none',
                 fillColor: 'white',
                 gradient: 'radial',
-                gradientSecondColor: colors[i],
+                gradientSecondColor: colors1[i],
                 gradientFX: 0.7,
                 gradientFY: 0.3,
-                highlightStrokeColor: '#600030'
+                highlightStrokeWidth: 1,
+                highlightStrokeColor: '#777'
             }
         ));
     }
 
-    // Polygon
-    let polygon = view.create('polygon3d', vertices);
+    // First polygon
+    let polygon1 = view.create(
+        'polygon3d',
+        vertices1,
+        {
+            borders: {
+                strokeColor: '#777',
+                highlightStrokeColor: '#999'
+            }
+        }
+    );
+
+    // Second polygon
+    let coords2 = [
+        [0.5, 1.5, 1.5],
+        [1.5, 1.5, 1.5],
+        [1.5, 2.5, 1.5],
+        [0.5, 2.5, 1.5]
+    ];
+    let polygon2 = view.create(
+        'polygon3d',
+        coords2,
+        {
+            vertices: {
+                withLabel: false,
+                size: 3,
+                strokeColor: 'none',
+                fillColor: 'white',
+                gradient: 'radial',
+                gradientSecondColor: '#444',
+                gradientFX: 0.7,
+                gradientFY: 0.3,
+                highlightStrokeWidth: 1,
+                highlightStrokeColor: 'black'
+            },
+            borders: {
+                strokeColor: 'black',
+                highlightStrokeColor: 'gray'
+            }
+        }
+    );
 </script>
 </body>
 </html>

--- a/examples/polygon3d.html
+++ b/examples/polygon3d.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Polygon in 3D</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" type="text/css" href="../distrib/jsxgraph.css" />
+    <script type="text/javascript" src="../distrib/jsxgraphcore.js"></script>
+</head>
+<body>
+
+<div id="jxgbox" class="jxgbox" style="width:800px; height:800px; float:left"></div>
+
+<script type="text/javascript">
+    let board = JXG.JSXGraph.initBoard(
+        'jxgbox',
+        {
+            boundingbox: [-8, 8, 8,-8],
+            axis: false,
+            showcopyright: false,
+            shownavigation: false
+        }
+    );
+    let view = board.create(
+        'view3d',
+        [[-6, -3], [8, 8],
+        [[0, 3], [0, 3], [0, 3]]],
+        {
+            xPlaneRear: {fillOpacity: 0.2, gradient: null},
+            yPlaneRear: {fillOpacity: 0.2, gradient: null},
+            zPlaneRear: {fillOpacity: 0.2, gradient: null}
+        }
+    );
+
+    // Vertices
+    let vertices = [];
+    coords = [
+        [2, 1, 1],
+        [2, 2, 1],
+        [1, 2, 1],
+        [1, 2, 2],
+        [1, 1, 2],
+        [1, 1, 1]
+    ];
+    colors = [
+        'orangered',
+        'gold',
+        'mediumseagreen',
+        'darkturquoise',
+        'purple',
+        'deeppink'
+    ];
+    for (let i = 0; i < coords.length; i++) {
+        vertices.push(view.create(
+            'point3d',
+            coords[i],
+            {
+                withLabel: false,
+                size: 5,
+                strokeWidth: 1,
+                strokeColor: colors[i],
+                fillColor: 'white',
+                gradient: 'radial',
+                gradientSecondColor: colors[i],
+                gradientFX: 0.7,
+                gradientFY: 0.3,
+                highlightStrokeColor: '#600030'
+            }
+        ));
+    }
+
+    // Polygon
+    let polygon = view.create('polygon3d', vertices);
+</script>
+</body>
+</html>

--- a/src/3d/polygon3d.js
+++ b/src/3d/polygon3d.js
@@ -1,0 +1,175 @@
+/*
+    Copyright 2008-2023
+        Matthias Ehmann,
+        Aaron Fenyes,
+        Carsten Miller,
+        Andreas Walter,
+        Alfred Wassermann
+
+    This file is part of JSXGraph.
+
+    JSXGraph is free software dual licensed under the GNU LGPL or MIT License.
+
+    You can redistribute it and/or modify it under the terms of the
+
+      * GNU Lesser General Public License as published by
+        the Free Software Foundation, either version 3 of the License, or
+        (at your option) any later version
+      OR
+      * MIT License: https://github.com/jsxgraph/jsxgraph/blob/master/LICENSE.MIT
+
+    JSXGraph is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public License and
+    the MIT License along with JSXGraph. If not, see <https://www.gnu.org/licenses/>
+    and <https://opensource.org/licenses/MIT/>.
+ */
+/*global JXG:true, define: true*/
+
+import JXG from '../jxg.js';
+import Const from '../base/constants.js';
+import Type from '../utils/type.js';
+
+// -----------------------
+//  Lines
+// -----------------------
+
+/**
+ * Constructor for 3D polygons.
+ * @class Creates a new 3D polygon object. Do not use this constructor to create a 3D polygon. Use {@link JXG.View3D#create} with type {@link Polygon3D} instead.
+ *
+ * @augments JXG.GeometryElement3D
+ * @augments JXG.GeometryElement
+ * @param {View3D} view
+ * @param {Point3D|Array} point
+ * @param {Array} direction
+ * @param {Array} range
+ * @param {Object} attributes
+ * @see JXG.Board#generateName
+ */
+JXG.Polygon3D = function (view, vertices, attributes) {
+    var i;
+
+    this.constructor(view.board, attributes, Const.OBJECT_TYPE_POLYGON3D, Const.OBJECT_CLASS_3D);
+    this.constructor3D(view, 'polygon3d');
+
+    this.board.finalizeAdding(this);
+
+    /**
+     * References to the points defining the polygon. The last vertex is the same as the first vertex.
+     * @type Array
+     */
+    this.vertices = [];
+    for (i = 0; i < vertices.length; i++) {
+        this.vertices[i] = this.board.select(vertices[i]);
+
+        // The _is_new flag is replaced by _is_new_pol.
+        // Otherwise, the polygon would disappear if the last border element
+        // is removed (and the point has been provided by coordinates)
+        if (this.vertices[i]._is_new) {
+            delete this.vertices[i]._is_new;
+            this.vertices[i]._is_new_pol = true;
+        }
+    }
+};
+JXG.Polygon3D.prototype = new JXG.GeometryElement();
+Type.copyPrototypeMethods(JXG.Polygon3D, JXG.GeometryElement3D, 'constructor3D');
+
+JXG.extend(
+    JXG.Polygon3D.prototype,
+    /** @lends JXG.Polygon3D.prototype */ {
+        update: function () {
+            return this;
+        },
+
+        updateRenderer: function () {
+            this.needsUpdate = false;
+            return this;
+        }
+    }
+);
+
+/**
+ * @class A polygon is a sequence of points connected by lines, with the last point
+ * connecting back to the first one. The points are given by:
+ * <ul>
+ *    <li> a list of Point3D objects,
+ *    <li> a list of coordinate arrays, or
+ *    <li> a function returning a list of coordinate arrays.
+ * </ul>
+ * Each two consecutive points of the list define a line.
+ * @pseudo
+ * @constructor
+ * @name Polygon
+ * @type JXG.Polygon
+ * @augments JXG.Polygon
+ * @throws {Exception} If the element cannot be constructed with the given parent objects an exception is thrown.
+ * @param {Array} vertices The polygon's vertices. If the first and the last vertex don't match the first one will be
+ * added to the array by the creator. Here, two points match if they have the same 'id' attribute.
+ */
+JXG.createPolygon3D = function (board, parents, attributes) {
+    var view = parents[0],
+        el, i, le, obj,
+        points = [],
+        points2d = [],
+        attr,
+        attr_points,
+        is_transform = false;
+
+    attr = Type.copyAttributes(attributes, board.options, 'polygon3d');
+    obj = board.select(parents[1]);
+    if (obj === null) {
+        // This is necessary if the original polygon is defined in another board.
+        obj = parents[1];
+    }
+    if (
+        Type.isObject(obj) &&
+        obj.type === Const.OBJECT_TYPE_POLYGON3D &&
+        Type.isTransformationOrArray(parents[2])
+    ) {
+        is_transform = true;
+        le = obj.vertices.length - 1;
+        attr_points = Type.copyAttributes(attributes, board.options, 'polygon3d', 'vertices');
+        for (i = 0; i < le; i++) {
+            if (attr_points.withlabel) {
+                attr_points.name =
+                    obj.vertices[i].name === '' ? '' : obj.vertices[i].name + "'";
+            }
+            points.push(board.create('point3d', [obj.vertices[i], parents[2]], attr_points));
+        }
+    } else {
+        points = Type.providePoints3D(view, parents.slice(1), attributes, 'polygon3d', ['vertices']);
+        if (points === false) {
+            throw new Error(
+                "JSXGraph: Can't create polygon3d with parent types other than 'point' and 'coordinate arrays' or a function returning an array of coordinates. Alternatively, a polygon3d and a transformation can be supplied"
+            );
+        }
+    }
+
+    el = new JXG.Polygon3D(view, points, attr);
+    el.isDraggable = true;
+
+    attr = el.setAttr2D(attr);
+    for (i = 0; i < points.length; i++) {
+        points2d.push(points[i].element2D);
+    }
+    el.element2D = board.create('polygon', points2d, attr);
+    el.addChild(el.element2D);
+    el.inherits.push(el.element2D);
+    el.element2D.setParents(el);
+
+    // Put the points in their positions
+    if (is_transform) {
+      el.prepareUpdate().update().updateVisibility().updateRenderer();
+      le = obj.vertices.length - 1;
+      for (i = 0; i < le; i++) {
+          points[i].prepareUpdate().update().updateVisibility().updateRenderer();
+      }
+    }
+
+    return el;
+};
+JXG.registerElement('polygon3d', JXG.createPolygon3D);

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3754,6 +3754,11 @@ declare namespace JXG {
             attributes?: Point3DAttributes
         ): Point3D;
         create(
+            elementType: "polygon3d",
+            parents: unknown[],
+            attributes?: Polygon3DAttributes
+        ): Polygon3D;
+        create(
             elementType: "sphere3d",
             parents: unknown[],
             attributes?: Sphere3DAttributes
@@ -3852,6 +3857,7 @@ declare namespace JXG {
         | 'plot'
         | 'point'
         | 'point3d'
+        | 'polygon3d'
         | 'polarline'
         | 'polepoint'
         | 'polygon'

--- a/src/index.js
+++ b/src/index.js
@@ -84,6 +84,7 @@ import './3d/circle3d.js';
 import './3d/point3d.js';
 import './3d/curve3d.js';
 import './3d/linspace3d.js';
+import './3d/polygon3d.js';
 import './3d/sphere3d.js';
 import './3d/surface3d.js';
 import './themes/mono_thin.js';

--- a/src/index2.js
+++ b/src/index2.js
@@ -81,6 +81,7 @@ export * from "./3d/box3d";
 export * from "./3d/point3d";
 export * from "./3d/curve3d";
 export * from "./3d/linspace3d";
+import * from "./3d/polygon3d.js";
 export * from "./3d/sphere3d";
 export * from "./3d/surface3d";
 

--- a/src/options3d.js
+++ b/src/options3d.js
@@ -299,6 +299,19 @@ JXG.extend(Options, {
         highlightStrokeColor: "#555555"
     },
 
+    polygon3d: {
+        /**#@+
+         * @visprop
+         */
+
+        highlight: false,
+        tabindex: -1,
+        strokeWidth: 1,
+        fillColor: 'none'
+
+        /**#@-*/
+    },
+
     sphere3d: {
         /**#@+
          * @visprop


### PR DESCRIPTION
This pull request adds an element, `Polygon3D`, that represents a polygon in 3D space.

The `Polygon3D` class is modeled on the `Polygon` class. In particular, a `Polygon3D` comes with a list of `Point3D` vertices, just as a `Polygon` comes with a list of `Point` vertices.

Each 3D vertex `v` comes with a 2D projection `v.element2D`. Similarly, a 3D polygon `p` comes with a 2D projection `p.element2D`, which is just the `Polygon` created from the 2D projections of the vertices.

To keep `Polygon3D` as similar as possible to the `Polygon`, I've included a construction method that creates a 3D polygon from another 3D polygon and a transformation. This construction method can't be used yet, because there are no 3D transformations available, but I think it's reasonable to keep it around, waiting for 3D transformations to be implemented.