### PR TITLE
add board attribute `zoom.center`

### DIFF
--- a/src/base/board.js
+++ b/src/base/board.js
@@ -2265,6 +2265,7 @@ JXG.extend(
                 zx = this.attr.zoom.factorx,
                 zy = this.attr.zoom.factory,
                 factor, dist, theta, bound,
+                zoomCenter,
                 doZoom = false,
                 dx, dy, cx, cy;
 
@@ -2337,6 +2338,7 @@ JXG.extend(
 
             } else if (this.attr.zoom.enabled && Math.abs(factor - 1.0) < 0.5) {
                 doZoom = false;
+                zoomCenter = this.attr.zoom.center;
                 // Pinch detected
                 if (this.attr.zoom.pinchhorizontal || this.attr.zoom.pinchvertical) {
                     dx = Math.abs(evt.touches[0].clientX - evt.touches[1].clientX);
@@ -2371,7 +2373,11 @@ JXG.extend(
                 }
 
                 if (doZoom) {
-                    this.zoomIn(cx, cy);
+                    if (zoomCenter === 'board') {
+                        this.zoomIn();
+                    } else { // including zoomCenter === 'auto'
+                        this.zoomIn(cx, cy);
+                    }
 
                     // Restore zoomFactors
                     this.attr.zoom.factorx = zx;
@@ -3879,12 +3885,19 @@ JXG.extend(
 
             evt = evt || window.event;
             var wd = evt.detail ? -evt.detail : evt.wheelDelta / 40,
-                pos = new Coords(Const.COORDS_BY_SCREEN, this.getMousePosition(evt), this);
+                zoomCenter = this.attr.zoom.center,
+                pos;
+
+            if (zoomCenter === 'board') {
+                pos = [];
+            } else { // including zoomCenter === 'auto'
+                pos = new Coords(Const.COORDS_BY_SCREEN, this.getMousePosition(evt), this).usrCoords;
+            }
 
             if (wd > 0) {
-                this.zoomIn(pos.usrCoords[1], pos.usrCoords[2]);
+                this.zoomIn(pos[1], pos[2]);
             } else {
-                this.zoomOut(pos.usrCoords[1], pos.usrCoords[2]);
+                this.zoomOut(pos[1], pos[2]);
             }
 
             this.triggerEventHandlers(['mousewheel'], [evt]);

--- a/src/options.js
+++ b/src/options.js
@@ -1435,6 +1435,7 @@ JXG.Options = {
          *   needShift: true,  // mouse wheel zooming needs pressing of the shift key
          *   min: 0.001,       // minimal values of {@link JXG.Board#zoomX} and {@link JXG.Board#zoomY}, limits zoomOut
          *   max: 1000.0,      // maximal values of {@link JXG.Board#zoomX} and {@link JXG.Board#zoomY}, limits zoomIn
+         *   center: 'auto',   // the center of zoom is calculated (position of mouse or center of two fingers), with 'board' you can use the boards center
          *
          *   pinch: true,      // pinch-to-zoom gesture for proportional zoom
          *   pinchHorizontal: true, // Horizontal pinch-to-zoom zooms horizontal axis. Only available if keepaspectratio:false
@@ -1460,6 +1461,7 @@ JXG.Options = {
             factorY: 1.25,
             wheel: true,
             needShift: true,
+            center: 'auto',
             min: 0.0001,
             max: 10000.0,
             pinch: true,


### PR DESCRIPTION
This PR adds an attribute `center` to the board option `zoom`. Possible values are `auto` and `board`.

`auto` uses the same mechanism as before: either the position of the mouse cursor or the center of the two-finger gesture is used as the center of the zoom.

`board` means that the center of the zoom is always in the current center of the board.