### PR TITLE
Improve coords projection to functiongraph

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jsxgraph",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jsxgraph",
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "(MIT OR LGPL-3.0-or-later)",
       "devDependencies": {
         "@eslint/eslintrc": "^3.1.0",

--- a/src/math/geometry.js
+++ b/src/math/geometry.js
@@ -3112,8 +3112,13 @@ JXG.extend(
 
             var x = point.X(),
                 y = point.Y(),
-                t = point.position || 0.0,
-                result = this.projectCoordsToCurve(x, y, t, curve, board);
+                t = point.position,
+                result;
+
+            if (!Type.exists(t)) {
+                t = Type.evaluate(curve.visProp.curvetype) === 'functiongraph' ? x : 0.0;
+            }
+            result = this.projectCoordsToCurve(x, y, t, curve, board);
 
             // point.position = result[1];
 
@@ -3202,6 +3207,21 @@ JXG.extend(
                 newCoordsObj = new Coords(Const.COORDS_BY_USER, newCoords, board);
             } else {
                 // 'parameter', 'polar', 'functiongraph'
+
+                if (Type.evaluate(curve.visProp.curvetype) === 'functiongraph') {
+                    let dy = Math.abs(y - curve.Y(x));
+                    if (!isNaN(dy)) {
+                        minX = x - dy;
+                        maxX = x + dy;
+                    } else {
+                        minX = curve.minX();
+                        maxX = curve.maxX();
+                    }
+                } else {
+                    minX = curve.minX();
+                    maxX = curve.maxX();
+                }
+
                 /** @ignore */
                 minfunc = function (t) {
                     var dx, dy;
@@ -3215,8 +3235,6 @@ JXG.extend(
 
                 f_old = minfunc(t);
                 steps = 50;
-                minX = curve.minX();
-                maxX = curve.maxX();
 
                 delta = (maxX - minX) / steps;
                 t_new = minX;


### PR DESCRIPTION
The `projectCoordsToCurve` function, where the curve is of type 'functiongraph', only considers the part of the target curve that is within the visible domain (with a 10% additional region) for the point to project to. Glider elements that are being defined on a functiongraph with initial coordinates outside this domain get projected incorrectly. 

An example is provided in this [JSFiddle](https://jsfiddle.net/vo0jb5zg/), where the initial coordinates `(8, 6.4)` are already on the target function `f(x) = 0.1 x ^2`, but the point ends up being projected to`(6, 3.6)`.

This PR provides a different search domain for projection points (coordinates) on a funtiongraph. For coordinates `(a, b)` and functiongraph `f(x)`, the vertical difference `dy := |b - f(a)|` is used to define the search domain `[a - dy, a + dy]`. This domain should always contain the best `x` that minimizes `(x - a)^2 + (f(x) - b)^2`, provided that `f(a)` is well-defined. If it doesn't exist, the approach falls back to the original computation.