### PR TITLE
Allow points to occlude each other correctly

### DIFF
--- a/examples/circle3d_glider.html
+++ b/examples/circle3d_glider.html
@@ -28,7 +28,8 @@
             xPlaneRear: {fillOpacity: 0.2, gradient: null},
             yPlaneRear: {fillOpacity: 0.2, gradient: null},
             zPlaneRear: {fillOpacity: 0.2, gradient: null},
-            bank: {slider: {visible: true}}
+            bank: {slider: {visible: true}},
+            depthOrderPoints: true
         }
     );
 

--- a/examples/intersection_sphere_sphere.html
+++ b/examples/intersection_sphere_sphere.html
@@ -35,7 +35,8 @@
             xPlaneRear: {fillOpacity: 0.2, gradient: null},
             yPlaneRear: {fillOpacity: 0.2, gradient: null},
             zPlaneRear: {fillOpacity: 0.2, gradient: null},
-            bank: {slider: {visible: true}}
+            bank: {slider: {visible: true}},
+            depthOrderPoints: true
         }
     );
 

--- a/examples/line3d_glider.html
+++ b/examples/line3d_glider.html
@@ -27,7 +27,8 @@
             xPlaneRear: {fillOpacity: 0.2, gradient: null},
             yPlaneRear: {fillOpacity: 0.2, gradient: null},
             zPlaneRear: {fillOpacity: 0.2, gradient: null},
-            bank: {slider: {visible: true}}
+            bank: {slider: {visible: true}},
+            depthOrderPoints: true
         }
     );
 

--- a/examples/polygon3d.html
+++ b/examples/polygon3d.html
@@ -27,7 +27,8 @@
         {
             xPlaneRear: {fillOpacity: 0.2, gradient: null},
             yPlaneRear: {fillOpacity: 0.2, gradient: null},
-            zPlaneRear: {fillOpacity: 0.2, gradient: null}
+            zPlaneRear: {fillOpacity: 0.2, gradient: null},
+            depthOrderPoints: true
         }
     );
 

--- a/src/3d/point3d.js
+++ b/src/3d/point3d.js
@@ -54,6 +54,11 @@ JXG.Point3D = function (view, F, slide, attributes) {
 
     this.board.finalizeAdding(this);
 
+    // add the new point to its view's point list
+    if (/* [PROTOTYPE] condition on whether depth ordering is turned on */ true) {
+        view.points.push(this);
+    }
+
     /**
      * Homogeneous coordinates of a Point3D, i.e. array of length 4: [w, x, y, z]. Usually, w=1 for finite points and w=0 for points
      * which are infinitely far.

--- a/src/3d/point3d.js
+++ b/src/3d/point3d.js
@@ -55,7 +55,7 @@ JXG.Point3D = function (view, F, slide, attributes) {
     this.board.finalizeAdding(this);
 
     // add the new point to its view's point list
-    if (/* [PROTOTYPE] condition on whether depth ordering is turned on */ true) {
+    if (view.visProp.depthorderpoints) {
         view.points.push(this);
     }
 

--- a/src/3d/view3d.js
+++ b/src/3d/view3d.js
@@ -76,7 +76,7 @@ JXG.View3D = function (board, parents, attributes) {
      * @Type Array
      * @private
      */
-    this.points = [];
+    this.points = this.visProp.depthorderpoints ? [] : null;
 
     /**
      * An array containing all geometric objects in this view in the order of construction.
@@ -728,7 +728,8 @@ JXG.extend(
                 [0, 0, 0, 1]
             ],
             mat2D, objectToClip, size,
-            dx, dy;
+            dx, dy,
+            objectsList;
 
         if (
             !Type.exists(this.el_slide) ||
@@ -813,6 +814,21 @@ JXG.extend(
                     mat2D,
                     Mat.matMatMult(Mat.matMatMult(this.matrix3DRot, stretch), this.shift).slice(0, 3)
                 );
+        }
+
+        // if depth-ordering for points was just switched on, initialize the
+        // list of points
+        if (this.visProp.depthorderpoints && this.points === null) {
+            objectsList = Object.values(this.objects);
+            this.points = objectsList.filter(
+                el => el.type === Const.OBJECT_TYPE_POINT3D
+            );
+        }
+
+        // if depth-ordering for points was just switched off, throw away the
+        // list of points
+        if (!this.visProp.depthorderpoints && this.points !== null) {
+            this.points = null;
         }
 
         // depth-order visible points. the `setLayer` method is used here to
@@ -1995,7 +2011,6 @@ JXG.createView3D = function (board, parents, attributes) {
     view.updateAngleSliderBounds();
 
     view.board.update();
-    console.log(view.visProp);
 
     return view;
 };

--- a/src/3d/view3d.js
+++ b/src/3d/view3d.js
@@ -818,7 +818,7 @@ JXG.extend(
         // depth-order visible points. the `setLayer` method is used here to
         // re-order the points within each layer: it has the side effect of
         // moving the target element to the end of the layer's child list
-        if (/* [PROTOTYPE] condition on whether depth ordering is turned on */ true && this.board.renderer && this.board.renderer.type === 'svg') {
+        if (this.visProp.depthorderpoints && this.board.renderer && this.board.renderer.type === 'svg') {
             var that = this,
                 compareDepth = function (a, b) {
                 var worldDiff = [0, a.coords[1] - b.coords[1], a.coords[2] - b.coords[2], a.coords[3] - b.coords[3]];
@@ -1995,6 +1995,7 @@ JXG.createView3D = function (board, parents, attributes) {
     view.updateAngleSliderBounds();
 
     view.board.update();
+    console.log(view.visProp);
 
     return view;
 };

--- a/src/options3d.js
+++ b/src/options3d.js
@@ -663,6 +663,15 @@ JXG.extend(Options, {
         fov: 1 / 5 * 2 * Math.PI,
 
         /**
+         * When this option is enabled, points closer to the screen are drawn
+         * over points further from the screen within each layer.
+         *
+         * @name View3D#depthOrderPoints
+         * @default false
+         */
+        depthOrderPoints: false,
+
+        /**
          * Fixed values for the view, which can be changed using keyboard keys `picture-up` and `picture-down`.
          * Array of the form: [[el0, az0, r0], [el1, az1, r1, ...[eln, azn, rn]]
          *


### PR DESCRIPTION
### Overview

The branch to be pulled allows 3d points to occlude each other correctly, addressing issue #674.

### How to try it

You enable occlusion by setting the `depthOrderPoints` option in View3D to `true`. I've enabled it in the `circle3d_glider.html`, `intersection_sphere_sphere.html`, `line3d_glider.html` and `polygon3d.html` examples.

### Implementation

The occlusion handler works by keeping a list of point elements alongside the associative array `View3D.objects` that contains all the view's elements. On every call to `update`, I select the visible points, sort them by depth, and then change their drawing order to match their depth order. The re-ordering is accomplished using a side effect of the SVG renderer's `setLayer` function: if you send a point to the layer it's already in, the point moves to the top of the layer.

To avoid overriding users' layer choices, the occlusion handler only changes the drawing order of points within each layer. I don't think JSXGraph documentation makes any promises about how elements will be ordered within each layer, so I think it's okay that the occlusion handler changes that ordering.