### PR TITLE
Improve stability line label anchor

### DIFF
--- a/src/base/line.js
+++ b/src/base/line.js
@@ -694,7 +694,7 @@ JXG.extend(
                     case "lft":
                     case "llft":
                     case "ulft":
-                        if (c1[1] <= c2[1]) {
+                        if (c1[1] < c2[1] + Mat.eps) {
                             x = c1[1];
                             y = c1[2];
                         } else {
@@ -705,7 +705,7 @@ JXG.extend(
                     case "rt":
                     case "lrt":
                     case "urt":
-                        if (c1[1] > c2[1]) {
+                        if (c1[1] > c2[1] + Mat.eps) {
                             x = c1[1];
                             y = c1[2];
                         } else {


### PR DESCRIPTION
Hi JSXGraph team,

A small bugfix for the label MetaPost positioning when vertical line elements have `straightFirst` or `straightLast` set to `false`. Due to small numerical imprecisions from computing `Geometry.calcStraight`, the `urt` and `ulft` anchor positions get mixed up. 

An example is shown [here](https://jsfiddle.net/jz1cowdx/1/) for the 'urt' anchor (the 'ulft' case and fix are analogous), where panning the canvas (without rotating the line) causes the label 'old' to occasionally 'jump' to the other end of the line. The 'new' label, the position of which is computed with the suggested fix, remains at the expected location where the old label moves. 

Rotating the line shows that all other behavior between the two labels has remained the same.

The fix uses the `Mat.eps` as tolerance, but since the `c1` and `c2` are defined in screen coordinates, a wider tolerance of `1`(pixel) could be considered as well.