### PR TITLE
Circle3D Stack Error

### DIFF
--- a/src/3d/circle3d.js
+++ b/src/3d/circle3d.js
@@ -264,7 +264,6 @@ JXG.createCircle3D = function (board, parents, attributes) {
     el = new JXG.Circle3D(view, center, normal, radius, attr);
 
     // update scene tree
-    el.center.addChild(el);
     el.addChild(el.curve);
 
     el.update();


### PR DESCRIPTION
`circle3d` created a `point3d` as a child but the `circle3d` was added as a child to the `point3d` so they had each other as child elements. This resulted in infinite recursion in the `addDescendants` function and then a stack size exceeded error. I fixed this by removing the `addChild` on the `point3d`.