### PR TITLE
add image to group  (needs some help)

### DIFF
--- a/src/base/group.js
+++ b/src/base/group.js
@@ -282,6 +282,13 @@ JXG.extend(
                     t = this.board.create("transform", [alpha, center[0], center[1]], {
                         type: "rotate"
                     });
+
+                    // bind any images
+                    for (el in this.objects) {
+                        if (this.objects[el].point.elType === 'image')
+                            t.bindTo(this.objects[el].point);
+                    }
+
                     t.update(); // This initializes t.matrix, which is needed if the action element is the first group element.
                 } else if (drag.action === "scaling") {
                     s = Geometry.distance(this.coords[drag.id].usrCoords.slice(1), center);
@@ -298,6 +305,13 @@ JXG.extend(
                         [1, 0, 0, center[0] * (1 - sx), sx, 0, center[1] * (1 - sy), 0, sy],
                         { type: "generic" }
                     );
+
+                    // bind any images
+                    for (el in this.objects) {
+                        if (this.objects[el].point.elType === 'image')
+                            t.bindTo(this.objects[el].point);
+                    }
+
                     t.update(); // This initializes t.matrix, which is needed if the action element is the first group element.
                 } else {
                     return this;
@@ -961,7 +975,58 @@ JXG.extend(
  *  })();
  * </script><pre>
  *
+ *  @example
  *
+ *        // Add an image and use the group tools to manipulate it
+ *       let urlImg = "https://jsxgraph.org/distrib/images/uccellino.jpg";
+ *       let lowleft = [-2, -1]
+ *
+ *       let col = 'blue';
+ *       let p = [];
+ *       p.push(board.create('point', lowleft, { size: 5, strokeColor: col, fillColor: col }));
+ *       p.push(board.create('point', [2, -1], { size: 5, strokeColor: 'yellow', fillColor: 'yellow', name: 'scale' }));
+ *       p.push(board.create('point', [2, 1], { size: 5, strokeColor: 'red', fillColor: 'red', name: 'rotate' }));
+ *       p.push(board.create('point', [-2, 1], { size: 5, strokeColor: col, fillColor: col, name: 'translate' }));
+ *
+ *       let im = board.create('image', [urlImg, lowleft, [2, 2]]);
+ *       let pol = board.create('polygon', p, { hasInnerPoints: true });
+ *
+ *       let g = board.create('group', p.concat(im))
+ *       // g.addPoint(im)   // image, but adds as a point
+ *
+ *       g.setRotationCenter(lowleft)
+ *       g.setRotationPoints([p[2]]);
+ *
+ *       g.setScaleCenter(p[0]).setScalePoints(p[1]);
+ *
+ * </pre><div class="jxgbox" id="JXGd19b800a-57a9-4303-b49a-8f5b7a5489f1" style="width: 400px; height: 300px;"></div>
+ * <script type="text/javascript">
+ *  (function () {
+ *       let board = JXG.JSXGraph.initBoard('JXGd19b800a-57a9-4303-b49a-8f5b7a5489f1')
+ *
+ *       // Add an image and use the group tools to manipulate it
+ *       let urlImg = "https://jsxgraph.org/distrib/images/uccellino.jpg";
+ *       let lowleft = [-2, -1]
+ *
+ *       let col = 'blue';
+ *       let p = [];
+ *       p.push(board.create('point', lowleft, { size: 5, strokeColor: col, fillColor: col }));
+ *       p.push(board.create('point', [2, -1], { size: 5, strokeColor: 'yellow', fillColor: 'yellow', name: 'scale' }));
+ *       p.push(board.create('point', [2, 1], { size: 5, strokeColor: 'red', fillColor: 'red', name: 'rotate' }));
+ *       p.push(board.create('point', [-2, 1], { size: 5, strokeColor: col, fillColor: col, name: 'translate' }));
+ *
+ *       let im = board.create('image', [urlImg, lowleft, [2, 2]]);
+ *       let pol = board.create('polygon', p, { hasInnerPoints: true });
+ *
+ *       let g = board.create('group', p.concat(im))
+ *       // g.addPoint(im)   // image, but adds as a point
+ *
+ *       g.setRotationCenter(lowleft)
+ *       g.setRotationPoints([p[2]]);
+ *
+ *       g.setScaleCenter(p[0]).setScalePoints(p[1]);
+ *  })();
+ * </script><pre>
  */
 JXG.createGroup = function (board, parents, attributes) {
     var attr = Type.copyAttributes(attributes, board.options, "group"),


### PR DESCRIPTION
I wanted to add an image to a group.  The transformations were already there, so all I had to do was add the bindings to the image.  I added an example in the docs on how to use it.

But it doesn't work correctly.  It works OK for the first transformation, but then it misbehaves.  

I think I need to update the action point in ` _update_apply_transformation(drag, t)`, but that seems to need some horrible hacking, and then serious testing.  I'm hoping you will say "Oh, it's easy to update, just do this..."

Otherwise, send it back, and I'll grind at it.   Grateful for any advice.  Thanks.

This example is at the bottom of this pull request's **Group** documentation page.

![image](https://github.com/user-attachments/assets/89429b50-07aa-468b-acc5-5ca3b4799f45)


