### PR TITLE
Remove singularity in sphere central projection

### DIFF
--- a/src/3d/sphere3d.js
+++ b/src/3d/sphere3d.js
@@ -240,16 +240,17 @@ JXG.extend(
                     inward;
 
                 if (distOffAxis > 1e-8) {
-                    // if the center of the sphere isn't too close to the view
+                    // if the center of the sphere isn't too close to the camera
                     // axis, find the direction in plane of the screen that
-                    // points from the center of the sphere toward the view axis
+                    // points from the center of the sphere toward the camera
+                    // axis
                     inward = [
                         -(p[0] * cam[1][1] + p[1] * cam[2][1]) / distOffAxis,
                         -(p[0] * cam[1][2] + p[1] * cam[2][2]) / distOffAxis,
                         -(p[0] * cam[1][3] + p[1] * cam[2][3]) / distOffAxis
                     ];
                 } else {
-                    // if the center of the sphere is very close to the view
+                    // if the center of the sphere is very close to the camera
                     // axis, choose an arbitrary unit vector in the plane of the
                     // screen
                     inward = [cam[1][1], cam[1][2], cam[1][3]];

--- a/src/3d/sphere3d.js
+++ b/src/3d/sphere3d.js
@@ -231,18 +231,29 @@ JXG.extend(
                     p = view.worldToFocal(that.center.coords, false),
                     distOffAxis = Mat.hypot(p[0], p[1]),
                     cam = view.boxToCam,
-                    inward = [
-                        -(p[0] * cam[1][1] + p[1] * cam[2][1]) / distOffAxis,
-                        -(p[0] * cam[1][2] + p[1] * cam[2][2]) / distOffAxis,
-                        -(p[0] * cam[1][3] + p[1] * cam[2][3]) / distOffAxis
-                    ],
                     r = that.Radius(),
                     angleOffAxis = Math.atan(-distOffAxis / p[2]),
                     steepness = Math.acos(r / Mat.norm(p)),
                     lean = angleOffAxis + steepness,
                     cos_lean = Math.cos(lean),
-                    sin_lean = Math.sin(lean);
+                    sin_lean = Math.sin(lean),
+                    inward;
 
+                if (distOffAxis > 1e-8) {
+                    // if the center of the sphere isn't too close to the view
+                    // axis, find the direction in plane of the screen that
+                    // points from the center of the sphere toward the view axis
+                    inward = [
+                        -(p[0] * cam[1][1] + p[1] * cam[2][1]) / distOffAxis,
+                        -(p[0] * cam[1][2] + p[1] * cam[2][2]) / distOffAxis,
+                        -(p[0] * cam[1][3] + p[1] * cam[2][3]) / distOffAxis
+                    ];
+                } else {
+                    // if the center of the sphere is very close to the view
+                    // axis, choose an arbitrary unit vector in the plane of the
+                    // screen
+                    inward = [cam[1][1], cam[1][2], cam[1][3]];
+                }
                 return view.project3DTo2D([
                     that.center.X() + r * (sin_lean * inward[0] + cos_lean * cam[3][1]),
                     that.center.Y() + r * (sin_lean * inward[1] + cos_lean * cam[3][2]),


### PR DESCRIPTION
Issue #727 is caused by a removable singularity in one of the functions we use to display a sphere in central projection. The incoming branch addresses the issue by removing the singularity.

In central projection, a sphere in space projects to an ellipse on the screen. We specify the ellipse by finding its two focal points and one point on it. When the center of the sphere isn't too close to the camera axis, we choose the point on the ellipse which is closest to the center of the screen, just like in the main branch. This point becomes ill-defined when the center of the sphere hits the camera axis. When the center of the sphere is very close to the camera axis, the ellipse is almost circular, so we instead find a point on the ellipse by choosing an arbitrary point on the approximating circle.