### PR TITLE
clean up of ARIA usage

### DIFF
--- a/src/base/board.js
+++ b/src/base/board.js
@@ -6547,11 +6547,6 @@ JXG.extend(
                             this.defaultAxes.y.setAttribute(value.y);
                         }
                         break;
-                    case 'description':
-                        this.document.getElementById(this.container + '_ARIAdescription')
-                            .innerHTML = value;
-                        this._set(key, value);
-                        break;
                     case 'title':
                         this.document.getElementById(this.container + '_ARIAlabel')
                             .innerHTML = value;

--- a/src/element/button.js
+++ b/src/element/button.js
@@ -249,7 +249,7 @@ JXG.createButton = function (board, parents, attributes) {
     //}
 
     // 1. Create empty button
-    par = [parents[0], parents[1], '<button type="button" style="width:100%;"></button>'];
+    par = [parents[0], parents[1], '<button type="button" style="width:100%;" tabindex="0"></button>'];
     t = board.create("text", par, attr);
     t.type = Type.OBJECT_TYPE_BUTTON;
 

--- a/src/element/input.js
+++ b/src/element/input.js
@@ -45,10 +45,10 @@ import Type from "../utils/type.js";
  * @ignore
  */
 var priv = {
-     /**
-     * @class
-     * @ignore
-     */
+    /**
+    * @class
+    * @ignore
+    */
 
     InputInputEventHandler: function (evt) {
         this._value = this.rendNodeInput.value;
@@ -252,10 +252,10 @@ JXG.createInput = function (board, parents, attributes) {
         parents[0],
         parents[1],
         '<span style="display:inline; white-space:nowrap; padding:0px;">' +
-            '<span></span><input type="text" maxlength="' +
-            attr.maxlength +
-            '" style="width:100%"/>' +
-            "</span>"
+        '<label></label><input type="text" maxlength="' +
+        attr.maxlength +
+        '" style="width:100%"/>' +
+        "</span>"
     ];
 
     // 1. Create input element with empty label
@@ -270,6 +270,7 @@ JXG.createInput = function (board, parents, attributes) {
     t.rendNodeTag.disabled = !!attr.disabled;
     t.rendNodeLabel.id = t.rendNode.id + "_label";
     t.rendNodeInput.id = t.rendNode.id + "_input";
+    t.rendNodeInput.setAttribute("aria-labelledby",t.rendNodeLabel.id);
 
     // 2. Set parents[3] (string|function) as label of the input element.
     // abstract.js selects the correct DOM element for the update
@@ -277,10 +278,10 @@ JXG.createInput = function (board, parents, attributes) {
 
     t._value = parents[2];
 
-     /**
-     * @class
-     * @ignore
-     */
+    /**
+    * @class
+    * @ignore
+    */
     t.update = function () {
         if (this.needsUpdate) {
             JXG.Text.prototype.update.call(this);
@@ -341,10 +342,10 @@ JXG.createInput = function (board, parents, attributes) {
      *
      */
 
-     /**
-     * @class
-     * @ignore
-     */
+    /**
+    * @class
+    * @ignore
+    */
 
     t.set = function (val) {
         this._value = val;

--- a/src/jsxgraph.js
+++ b/src/jsxgraph.js
@@ -244,23 +244,8 @@ JXG.JSXGraph = {
         doc_glob = node_jsx.ownerDocument; // This is the window.document element, needed below.
         parent = node_jsx.parentNode;
 
-        id_label = container + "_ARIAlabel";
-        id_description = container + "_ARIAdescription";
-
-        newNode = doc_glob.createElement("div");
-        newNode.innerHTML = attr.title;
-        newNode.setAttribute("id", id_label);
-        newNode.style.display = "none";
-        parent.insertBefore(newNode, node_jsx);
-
-        newNode = doc_glob.createElement("div");
-        newNode.innerHTML = attr.description;
-        newNode.setAttribute("id", id_description);
-        newNode.style.display = "none";
-        parent.insertBefore(newNode, node_jsx);
-
-        node_jsx.setAttribute("aria-labelledby", id_label);
-        node_jsx.setAttribute("aria-describedby", id_description);
+        node_jsx.setAttribute("role", "region");
+        node_jsx.setAttribute("aria-label", attr.title);              // set by initBoard( {title:})
     },
 
     /**

--- a/src/options.js
+++ b/src/options.js
@@ -375,21 +375,6 @@ JXG.Options = {
         },
 
         /**
-         * Description string for the board.
-         * Primarily used in an invisible text element which is adressed by
-         * the attribute 'aria-describedby' from the JSXGraph container.
-         * JSXGraph creates a new div-element with id "{containerid}_ARIAdescription"
-         * containing this string.
-         *
-         * @name JXG.Board#description
-         * @see JXG.Board#title
-         * @type String
-         * @default ''
-         *
-         */
-        description: '',
-
-        /**
          * Supply the document object. Defaults to window.document
          *
          * @name JXG.Board#document
@@ -1395,13 +1380,14 @@ JXG.Options = {
 
         /**
          * Title string for the board.
-         * Primarily used in an invisible text element which is adressed by
-         * the attribute 'aria-labelledby' from the JSXGraph container.
-         * JSXGraph creates a new div-element with id "{containerid}_ARIAlabel"
-         * containing this string.
+         * Primarily used in an invisible text element for assistive technologies.
+         * The title is implemented with the attribute 'aria-label' in the JSXGraph container.
+         *
+         * Content should be accessible to all users, not just to those with
+         * screen readers.  Consider instead adding a text element with the title and add the attribute
+         * <b>aria:{enable:true,label:"Your Title"}</b>
          *
          * @name JXG.Board#title
-         * @see JXG.Board#description
          * @type String
          * @default ''
          *
@@ -2403,7 +2389,7 @@ JXG.Options = {
          * @see JXG.GeometryElement#fixed
          * @see JXG.GeometryElement#visible
          */
-        tabindex: 0,
+        tabindex: -1,
 
         /**
          * If true the element will be traced, i.e. on every movement the element will be copied

--- a/src/renderer/abstract.js
+++ b/src/renderer/abstract.js
@@ -2093,6 +2093,8 @@ JXG.extend(
                     // button.setAttribute('tabindex', 0);
 
                     button.setAttribute("id", board_id + '_navigation_' + type);
+                    button.setAttribute("aria-hidden", 'true');   // navigation buttons should never appear in screen reader
+
                     node.appendChild(button);
 
                     Env.addEvent(

--- a/src/renderer/svg.js
+++ b/src/renderer/svg.js
@@ -612,6 +612,7 @@ JXG.extend(
             node.setAttributeNS(null, 'style', 'font-family:Arial,Helvetica,sans-serif; font-size:' +
                 fontsize + 'px; fill:#356AA0;  opacity:0.3;');
             t = this.container.ownerDocument.createTextNode(str);
+            node.setAttributeNS(null, 'aria-hidden', 'true');  // should NEVER be in screen reader
             node.appendChild(t);
             this.appendChildPrim(node, 0);
         },
@@ -1358,6 +1359,7 @@ JXG.extend(
 
         // documented in JXG.AbstractRenderer
         setCssClass(el, cssClass) {
+
             if (el.visPropOld.cssclass !== cssClass) {
                 this.setPropertyPrim(el.rendNode, 'class', cssClass);
                 el.visPropOld.cssclass = cssClass;


### PR DESCRIPTION
Some minimal changes to ARIA usage.

- default tabindex is -1.  buttons are set to tabindex=0, and form elements like checkbox don't need this setting.
- always hid the copyright message and JSX navigation buttons from assistive technology.  
- board.title requires a role to appear in aria.  Since it is just a `div`, assistive readers will ignore it without a role.  No point in 'aria-labelledby', which is intended to point to visible elements, so just pop title in with 'aria-label'.
- board.description doesn't work on a `div`.  Descriptions are intended for interactive elements.  Removed it from options.js.

Two things I was unable to figure out, hopefully you can complete this for me.
- how to set the labels on an axis to 'aria-ignore'.  The screen readers should not be reading '2 4 6 8', etc.
- how to set tabindex=0 on the glider part of a slider.

Here's what the test program looks like to the screenreader now:

![image](https://github.com/user-attachments/assets/3bd3075d-d7c9-4ba8-a41a-ff04b7b92208)

