### PR TITLE
Fix grid.getParents

### DIFF
--- a/src/element/grid.js
+++ b/src/element/grid.js
@@ -1043,7 +1043,7 @@ JXG.createGrid = function (board, parents, attributes) {
 
     majorGrid.getParents = minorGrid.getParents = function() {
         return parentAxes.slice();
-    }
+    };
 
     return majorGrid;
 };

--- a/src/element/grid.js
+++ b/src/element/grid.js
@@ -1039,6 +1039,10 @@ JXG.createGrid = function (board, parents, attributes) {
     board.grids.push(majorGrid);
     board.grids.push(minorGrid);
 
+    majorGrid.getParents = minorGrid.getParents = function() {
+        return parentAxes.slice();
+    }
+
     return majorGrid;
 };
 

--- a/src/element/grid.js
+++ b/src/element/grid.js
@@ -1039,6 +1039,8 @@ JXG.createGrid = function (board, parents, attributes) {
     board.grids.push(majorGrid);
     board.grids.push(minorGrid);
 
+    minorGrid.dump = false;
+
     majorGrid.getParents = minorGrid.getParents = function() {
         return parentAxes.slice();
     }


### PR DESCRIPTION
The `getParents` method on grid objects was inheriting getParents from `Curve`, which led to an error when trying to use that list to create a new grid object.

This PR overrides `getParents` on grid objects so that it returns just the `parentAxes` list.

I've also set `dump = false` on the minor grid object, because I think it's created by the major object.

The immediate problem I had, prompting me to make this change, was that dumping a board with a grid to JessieCode and then creating a new board from that dump threw an error because the grid was given an invalid list of parents. 

I'd appreciate some help writing unit tests for this.