### PR TITLE
addition for sketchometry and for board in board

### DIFF
--- a/src/element/measure.js
+++ b/src/element/measure.js
@@ -349,7 +349,15 @@ JXG.createMeasurement = function (board, parents, attributes) {
     el.Unit = function (dimension) {
         var unit = '',
             units = el.evalVisProp('units'),
-            dim = dimension ?? el.Dimension();
+            dim = dimension ?? el.Dimension(),
+            dims = {}, i;
+
+        if (Type.isArray(dimension)) {
+            for (i = 0; i < dimension.length; i++) {
+                dims['dim' + dimension[i]] = el.Unit(dimension[i]);
+            }
+            return dims;
+        }
 
         if (Type.isObject(units) && Type.exists(units[dim]) && units[dim] !== false) {
             unit = el.eval(units[dim]);

--- a/src/options.js
+++ b/src/options.js
@@ -4967,7 +4967,18 @@ JXG.Options = {
          * @type Array
          * @default empty
          */
-        attractors: []
+        attractors: [],
+
+        /**
+         * If set to true, this object is only evaluated once and not re-evaluated on update.
+         * This is necessary if you want to have a bord within a foreignObject of another board.
+         *
+         * @name ForeignObject#evaluateOnlyOnce
+         *
+         * @type Boolean
+         * @default false
+         */
+        evaluateOnlyOnce: false
 
         /**#@-*/
     },

--- a/src/renderer/svg.js
+++ b/src/renderer/svg.js
@@ -804,7 +804,10 @@ JXG.extend(
                 el.size[1]
             );
 
-            el.rendNode.innerHTML = el.content;
+            if (el.evalVisProp('evaluateOnlyOnce') !== true || !el.renderedOnce) {
+                el.rendNode.innerHTML = el.content;
+                el.renderedOnce = true;
+            }
             this._updateVisual(el, { stroke: true, dash: true }, true);
         },
 


### PR DESCRIPTION
This PR hast two improvements:

- we introduce an attribute `evaluateOnlyOnce` for foreignObjects to support boards in boards
- we add an param to `Unit` function of measurement. This is needed in sketchometry