### PR TITLE
more param options for Sphere3d, Polygon3d

### DIFF
--- a/src/3d/polygon3d.js
+++ b/src/3d/polygon3d.js
@@ -165,6 +165,8 @@ JXG.createPolygon3D = function (board, parents, attributes) {
             }
             points.push(board.create('point3d', [obj.vertices[i], parents[2]], attr_points));
         }
+    } else if (Type.isArray(parents[1]) && parents[1].every((x) => Type.isPoint3D(x))) {  // array of points
+        points = parents[1];
     } else {
         points = Type.providePoints3D(view, parents.slice(1), attributes, 'polygon3d', ['vertices']);
         if (points === false) {
@@ -189,11 +191,11 @@ JXG.createPolygon3D = function (board, parents, attributes) {
 
     // Put the points in their positions
     if (is_transform) {
-      el.prepareUpdate().update().updateVisibility().updateRenderer();
-      le = obj.vertices.length - 1;
-      for (i = 0; i < le; i++) {
-          points[i].prepareUpdate().update().updateVisibility().updateRenderer();
-      }
+        el.prepareUpdate().update().updateVisibility().updateRenderer();
+        le = obj.vertices.length - 1;
+        for (i = 0; i < le; i++) {
+            points[i].prepareUpdate().update().updateVisibility().updateRenderer();
+        }
     }
 
     return el;

--- a/src/3d/sphere3d.js
+++ b/src/3d/sphere3d.js
@@ -596,15 +596,18 @@ JXG.createSphere3D = function (board, parents, attributes) {
     if (Type.isPoint3D(p[0]) && Type.isPoint3D(p[1])) {
         // Point/Point
         el = new JXG.Sphere3D(view, "twoPoints", p[0], p[1], attr);
+
+        /////////////// nothing in docs suggest you can use [number, pointType]
+        // } else if (
+        //     (Type.isNumber(p[0]) || Type.isFunction(p[0]) || Type.isString(p[0])) &&
+        //     Type.isPoint3D(p[1])
+        // ) {
+        //     // Number/Point
+        //     el = new JXG.Sphere3D(view, "pointRadius", p[1], p[0], attr);
+
     } else if (
-        (Type.isNumber(p[0]) || Type.isFunction(p[0]) || Type.isString(p[0])) &&
-        Type.isPoint3D(p[1])
-    ) {
-        // Number/Point
-        el = new JXG.Sphere3D(view, "pointRadius", p[1], p[0], attr);
-    } else if (
-        (Type.isNumber(p[1]) || Type.isFunction(p[1]) || Type.isString(p[1])) &&
-        Type.isPoint3D(p[0])
+        Type.isPoint3D(p[0]) &&
+        (Type.isNumber(p[1]) || Type.isFunction(p[1]) || Type.isString(p[1]))
     ) {
         // Point/Number
         el = new JXG.Sphere3D(view, "pointRadius", p[0], p[1], attr);

--- a/src/base/element.js
+++ b/src/base/element.js
@@ -414,7 +414,7 @@ JXG.extend(
             var el, el2;
 
             this.childElements[obj.id] = obj;
-            this.addDescendants(obj);
+            // this.addDescendants(obj);
             obj.ancestors[this.id] = this;
 
             for (el in this.descendants) {

--- a/src/options3d.js
+++ b/src/options3d.js
@@ -708,7 +708,7 @@ JXG.extend(Options, {
          * @default 1
          *
          */
-        stepWidthV: 1,
+        stepWidthV: 1
 
         /**#@-*/
     },

--- a/src/utils/type.js
+++ b/src/utils/type.js
@@ -442,11 +442,11 @@ JXG.extend(
                 /** @ignore */
                 f = function () { return term; };
                 f.deps = {};
-            // } else if (this.isString(term)) {
-            //     // In case of string function like fontsize
-            //     /** @ignore */
-            //     f = function () { return term; };
-            //     f.deps = {};
+                // } else if (this.isString(term)) {
+                //     // In case of string function like fontsize
+                //     /** @ignore */
+                //     f = function () { return term; };
+                //     f.deps = {};
             }
 
             if (f !== null) {
@@ -580,9 +580,18 @@ JXG.extend(
                     );
                 }
 
-                if (this.isArray(parents[i]) && parents[i].length > 1) {
-                    points.push(view.create("point3d", parents[i], attr));
+                // testing for array-of-arrays-of-numbers, like [[1,2,3],[2,3,4]]
+                if (this.isArray(parents[i]) && parents[i].length > 0 && parents[i].every((x)=>this.isArray(x) && this.isNumber(x[0]))) {
+                    for (j = 0; j < parents[i].length; j++) {
+                        points.push(view.create("point3d", parents[i][j], attr));;
+                        points[points.length - 1]._is_new = true;
+                    }
+                } else if (this.isArray(parents[i]) &&  parents[i].every((x)=>this.isNumber(x))) {
+                    points.push(view.create("point3d", parents[i], attr));   // single array [1,2,3]
                     points[points.length - 1]._is_new = true;
+
+                } else if (this.isPoint3D(parents[i])) {
+                    points.push(parents[i]);
                 } else if (this.isFunction(parents[i])) {
                     val = parents[i]();
                     if (this.isArray(val) && val.length > 1) {


### PR DESCRIPTION
Dear Alfred,

I was trying Sphere3d and Polygon3d with different kinds of parameters, and some were failing.   I looked at the code, and the logical place to fix it seemed to be `providePoints3d` in Type.js.    

(It took me a while to realize that some 3d elements make a point from an array of four numbers ( [0,0,0,0] ), what is that about?)

Here is a summary of my changes: 
-----

Type.js:  providePoints3d now also handles array of points [[1,2,3],[2,3,4]] and [point3D,point3D]

element.js:  removed call to addDescendents(), the code immediately below already handles that.  Calling addDescendents() sometimes causes an infinite loop.

Sphere3d:  commented testing for sphere3d(radius, point), not supported in documentation.  Then let providePoints3d handle the muddled case.

Polygon3d:  enabled Polygon3d(point3d, point3d…) 

Options3d:  removed dangling comma, wasn’t me that put it there, required for eslint check.

  