### PR TITLE
fixups for parsing web documents

### DIFF
--- a/doc/jsdoc-tk/template/class.tmpl
+++ b/doc/jsdoc-tk/template/class.tmpl
@@ -105,7 +105,7 @@
 					</tr>
 				</thead>
 				<tbody>
-					<tr data-constructor="{+data.alias+} data-signature="{+makeSignature(data.params)+}">
+					<tr data-constructor="{+data.alias+}" data-description="{+resolveLinks(summarize(data.desc))+}">
 						<td class="attributes">{!
 							if (data.isPrivate) output += "&lt;private&gt; ";
 							if (data.isInner) output += "&lt;inner&gt; ";
@@ -135,7 +135,9 @@
 					</thead>
 					<tbody>
 					<for each="member" in="ownAttributes">
-						<tr data-attributes="{+member.name+}" data-type="{+member.type+}">
+						<tr data-attributes="{+member.name+}" data-type="{+member.type+}" data-description="{+member.desc+}" data-ignore="{!
+                                        if (member.isPrivate) output += "ignore";
+                                        if (member.deprecated) output += "ignore"; !}">
 							<td class="attributes">{!
 								if (member.isPrivate) output += "&lt;private&gt; ";
 								if (member.isInner) output += "&lt;inner&gt; ";
@@ -198,7 +200,11 @@
 					</thead>
 					<tbody>
 					<for each="member" in="ownProperties">
-						<tr data-fields="{+member.name+} data-type="{+member.type+}">
+						<tr data-fields="{+member.name+}" data-description="{+member.desc+}" data-type="{+member.type+}" data-ignore="{!
+                                        if (member.isPrivate) output += "ignore";
+                                        if (member.deprecated) output += "ignore";
+                                            !}">
+>
 							<td class="attributes">{!
 								if (member.isPrivate) output += "&lt;private&gt; ";
 								if (member.isInner) output += "&lt;inner&gt; ";
@@ -261,7 +267,11 @@
 					</thead>
 					<tbody>
 					<for each="member" in="ownMethods">
-   						<tr data-methods="{+member.name+}" data-returns="{+member.type+}" data-signature='{+makeMethodSignature(member.params)+}'>
+   						<tr data-methods="{+member.name+}" data-returns="{+member.type+}" data-signature="{+makeMethodSignature(member.params)+}" data-ignore="{!
+                                        if (member.isPrivate) output += "ignore";
+                                        if (member.deprecated) output += "ignore";
+                                            !}">
+
 							<td class="attributes">{!
 								if (member.isPrivate) output += "&lt;private&gt; ";
 								if (member.isInner) output += "&lt;inner&gt; ";

--- a/src/math/ia.js
+++ b/src/math/ia.js
@@ -285,6 +285,24 @@ JXG.extend(MatInterval.prototype, {
  * Object for interval arithmetics.
  * @name JXG.Math.IntervalArithmetic
  * @namespace
+ *
+ * Interval arithmetic is a technique used to mitigate rounding and measurement errors in mathematical computation
+ * by computing function bounds. Instead of representing a value as a single number, interval arithmetic represents each value as a range.
+ * <br><br>
+ *
+ * For example, we wish to calculate the area of a rectangle from direct measurements using a standard meter stick with an uncertainty
+ * of 0.0005 m (half the “least count measurement” of 1 mm). We measure one side nominally as L=1,
+ * so 0.9995 ≤ L ≤ 1.0005, the other nominally as W=2 so the interval is [1.9995, 2.0005].
+ *
+ * <pre>
+ * let L = JXG.Math.IntervalArithmetic.Interval(0.9995, 1.0005)
+ * let W = JXG.Math.IntervalArithmetic.Interval(1.9995, 2.0005)
+ *
+ * let A = JXG.Math.IntervalArithmetic.mul(L, W)
+ *
+ * console.log('area:', A)       //  {hi: 2.0015002500000003, lo: 1.99850025}
+ * </pre>
+ *
  */
 JXG.Math.IntervalArithmetic = {
     Interval: function (lo, hi) {

--- a/src/math/ia.js
+++ b/src/math/ia.js
@@ -300,7 +300,7 @@ JXG.extend(MatInterval.prototype, {
  *
  * let A = JXG.Math.IntervalArithmetic.mul(L, W)
  *
- * console.log('area:', A) // [2.0015002500000003, lo: 1.99850025}
+ * console.log('area:', A) // {hi: 2.0015002500000003, lo: 1.99850025}
  * </pre>
  *
  */

--- a/src/math/ia.js
+++ b/src/math/ia.js
@@ -107,8 +107,8 @@ JXG.Math.DoubleBits = function () {
             this.pack = toDoubleBE;
             this.lo = lowUintBE;
             this.hi = highUintBE;
-        // } else {
-        //     hasTypedArrays = false;
+            // } else {
+            //     hasTypedArrays = false;
         }
     }
 
@@ -300,7 +300,7 @@ JXG.extend(MatInterval.prototype, {
  *
  * let A = JXG.Math.IntervalArithmetic.mul(L, W)
  *
- * console.log('area:', A)       //  {hi: 2.0015002500000003, lo: 1.99850025}
+ * console.log('area:', A) // [2.0015002500000003, lo: 1.99850025}
  * </pre>
  *
  */


### PR DESCRIPTION
Dear Alfred,

I have written code that finds extra/missing discrepancies between the attributes, methods, and fields of each element.   It won't automatically check types or descriptions, but it will alert us if something needs to be added or deleted.

But I had originally planned to parse the HTML for some items, but decided it was more reliable to add them as data-elements.  As well, there were some small errors (a missing quote, using single-quotes instead of double-quotes for signatures).

Please accept these changes to the documentation website.

If you are curious, here's the result from testing the 'curve' element.    Lots of cleanup ahead, but it is now plausible to keep the two interfaces in synch.

![image](https://github.com/user-attachments/assets/aeb26bab-0ff8-49f9-9ebe-93786abcd0be)

