### PR TITLE
stop propagation on input field

### DIFF
--- a/src/element/input.js
+++ b/src/element/input.js
@@ -270,13 +270,25 @@ JXG.createInput = function (board, parents, attributes) {
     t.rendNodeTag.disabled = !!attr.disabled;
     t.rendNodeLabel.id = t.rendNode.id + "_label";
     t.rendNodeInput.id = t.rendNode.id + "_input";
-    t.rendNodeInput.setAttribute("aria-labelledby",t.rendNodeLabel.id);
+    t.rendNodeInput.setAttribute("aria-labelledby", t.rendNodeLabel.id);
 
     // 2. Set parents[3] (string|function) as label of the input element.
     // abstract.js selects the correct DOM element for the update
     t.setText(parents[3]);
 
     t._value = parents[2];
+
+    // 3.  capture keydown events on the input, and do not let them propagate.  The problem is that
+    // elevation controls on view3D use left and right, so editing the input triggers 3D pan.
+    t.rendNodeInput.addEventListener("keydown", (event) => {
+        // only trap left-and-right in case user wants input editing events
+        if (event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+            event.stopPropagation();
+        }
+    });
+
+
+
 
     /**
     * @class


### PR DESCRIPTION
If you enable the keyboard to control the View3D trackball, it must capture the arrow keys.

That conflicts with Input elements, which also need the left and right arrow keys.   The result is that arrow keys in Input fields over a View3D are captured by the elevation and azimuth controls.

This PR adds an event listener to each input field that captures the arrow keys and stops them from propagating.  Arrow keys outside an input field propagate normally.


Below is a minimal example.

```
<!DOCTYPE html>
<html lang="en">

<head>
    <meta charset="utf-8" />
    <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
</head>

<body>
    <div id="jxgbox" class="jxgbox" tabindex='0' style="width:1000px; height:1000px;float:left;"></div>
    <script>
        let board = JXG.JSXGraph.initBoard("jxgbox")
        let bound = [-4, 6];
        let view = board.create('view3d',
            [[-5, -5], [10, 10],
            [bound, bound, bound]],
            {
                projection: 'central',
                pan: { enabled: false },
                trackball: { enabled: true },
                depthOrder: {
                    enabled: true,
                },
                depthOrderPoints: true,
                xPlaneRear: { visible: false },
                yPlaneRear: { visible: false },
                zPlaneRear: { fillOpacity: 0.2, fillColor: 'blue' },
                az: { pointer: { enabled: false }, keyboard: { enabled: true, key: 'none' } },
                el: { pointer: { enabled: false }, keyboard: { enabled: true, key: 'none' } },
            });

        let inp = board.create('input', [1, 1, 'Math.sin(x)*x', 'f(x)=']);

    </script>
</body>
</html>

