### PR TITLE
Improvements to slope triangle

### DIFF
--- a/src/element/measure.js
+++ b/src/element/measure.js
@@ -488,6 +488,7 @@ JXG.createMeasurement = function (board, parents, attributes) {
 
     el.methodMap = Type.deepCopy(el.methodMap, {
         Value: "Value",
+        V: "Value",
         Dimension: "Dimension",
         Unit: "Unit",
         getTerm: "getTerm",

--- a/src/element/slopetriangle.js
+++ b/src/element/slopetriangle.js
@@ -60,6 +60,32 @@ var priv = {
     Value: function () {
         return this.tangent.getSlope();
     },
+    Unit: function (dimension) {
+        var unit = '',
+            units = this.evalVisProp('units'),
+            dim = dimension;
+
+        if (!Type.exists(dim)) {
+            dim = 0;
+        }
+
+        if (Type.isObject(units) && Type.exists(units[dim]) && units[dim] !== false) {
+            unit = this.eval(units[dim]);
+        } else if (Type.isObject(units) && Type.exists(units['dim' + dim]) && units['dim' + dim] !== false) {
+            // In some cases, object keys must not be numbers. This allows key 'dim1' instead of '1'.
+            unit = this.eval(units['dim' + dim]);
+        } else {
+            unit = this.evalVisProp('baseunit');
+
+            if (dim === 0) {
+                unit = '';
+            } else if (dim > 1 && unit !== '') {
+                unit = unit + '^{' + dim + '}';
+            }
+        }
+
+        return unit;
+    },
     Direction: function() {
         return this.tangent.Direction();
     }
@@ -193,6 +219,16 @@ JXG.createSlopeTriangle = function (board, parents, attributes) {
     el.Value = priv.Value;
 
     /**
+     * Returns the unit of the slope triangle, of the slope of the tangent.
+     * Of course a slope has no dimension and though no unit. But this function will be used to determ unit of horizontal and vertical length.
+     * @name Unit
+     * @memberOf Slopetriangle.prototype
+     * @function
+     * @returns {Number} unit of the slope triangle.
+     */
+    el.Unit = priv.Unit;
+
+    /**
      * Returns the direction of the slope triangle, that is the direction of the tangent.
      * @name Direction
      * @memberOf Slopetriangle.prototype
@@ -237,13 +273,37 @@ JXG.createSlopeTriangle = function (board, parents, attributes) {
     el.borders[1].hasLabel = true;
     el.borders[1].visProp.withlabel = true;
 
-    label._setText(function () {
-        var digits = label.evalVisProp('digits');
+    label.setText(function () {
+        var prefix = '',
+            suffix = '',
+            digits = label.evalVisProp('digits'),
+            unit = el.Unit(),
+            val = el.Value();
 
-        if (label.useLocale()) {
-            return label.formatNumberLocale(el.Value(), digits);
+        if (label.evalVisProp('showprefix')) {
+            prefix = label.evalVisProp('prefix');
         }
-        return Type.toFixed(el.Value(), digits);
+        if (label.evalVisProp('showsuffix')) {
+            suffix = label.evalVisProp('suffix');
+        }
+
+        if (digits === 'none') {
+            // do nothing
+        } else if (digits === 'auto') {
+            if (label.useLocale()) {
+                val = label.formatNumberLocale(val);
+            } else {
+                val = Type.autoDigits(val);
+            }
+        } else {
+            if (label.useLocale()) {
+                val = label.formatNumberLocale(val, digits);
+            } else {
+                val = Type.toFixed(val, digits);
+            }
+        }
+
+        return prefix + val + unit + suffix;
     });
     label.fullUpdate();
 
@@ -271,6 +331,7 @@ JXG.createSlopeTriangle = function (board, parents, attributes) {
         label: "label",
         Value: "Value",
         V: "Value",
+        Unit: "Unit",
         Direction: "Direction"
     });
 

--- a/src/element/slopetriangle.js
+++ b/src/element/slopetriangle.js
@@ -60,32 +60,6 @@ var priv = {
     Value: function () {
         return this.tangent.getSlope();
     },
-    Unit: function (dimension) {
-        var unit = '',
-            units = this.evalVisProp('units'),
-            dim = dimension;
-
-        if (!Type.exists(dim)) {
-            dim = 0;
-        }
-
-        if (Type.isObject(units) && Type.exists(units[dim]) && units[dim] !== false) {
-            unit = this.eval(units[dim]);
-        } else if (Type.isObject(units) && Type.exists(units['dim' + dim]) && units['dim' + dim] !== false) {
-            // In some cases, object keys must not be numbers. This allows key 'dim1' instead of '1'.
-            unit = this.eval(units['dim' + dim]);
-        } else {
-            unit = this.evalVisProp('baseunit');
-
-            if (dim === 0) {
-                unit = '';
-            } else if (dim > 1 && unit !== '') {
-                unit = unit + '^{' + dim + '}';
-            }
-        }
-
-        return unit;
-    },
     Direction: function() {
         return this.tangent.Direction();
     }
@@ -219,16 +193,6 @@ JXG.createSlopeTriangle = function (board, parents, attributes) {
     el.Value = priv.Value;
 
     /**
-     * Returns the unit of the slope triangle, of the slope of the tangent.
-     * Of course a slope has no dimension and though no unit. But this function will be used to determ unit of horizontal and vertical length.
-     * @name Unit
-     * @memberOf Slopetriangle.prototype
-     * @function
-     * @returns {Number} unit of the slope triangle.
-     */
-    el.Unit = priv.Unit;
-
-    /**
      * Returns the direction of the slope triangle, that is the direction of the tangent.
      * @name Direction
      * @memberOf Slopetriangle.prototype
@@ -283,7 +247,6 @@ JXG.createSlopeTriangle = function (board, parents, attributes) {
         var prefix = '',
             suffix = '',
             digits = label.evalVisProp('digits'),
-            unit = el.Unit(),
             val = el.Value();
 
         if (label.evalVisProp('showprefix')) {
@@ -309,7 +272,7 @@ JXG.createSlopeTriangle = function (board, parents, attributes) {
             }
         }
 
-        return prefix + val + unit + suffix;
+        return prefix + val + suffix;
     });
     label.fullUpdate();
 
@@ -340,7 +303,6 @@ JXG.createSlopeTriangle = function (board, parents, attributes) {
         label: "label",
         Value: "Value",
         V: "Value",
-        Unit: "Unit",
         Direction: "Direction"
     });
 

--- a/src/element/slopetriangle.js
+++ b/src/element/slopetriangle.js
@@ -240,9 +240,13 @@ JXG.createSlopeTriangle = function (board, parents, attributes) {
     el.tangent = tangent;
     el._isPrivateTangent = isPrivateTangent;
 
-    //el.borders[0].setArrow(false, {type: 2, size: 10});
-    //el.borders[1].setArrow(false, {type: 2, size: 10});
-    el.borders[2].setArrow(false, false);
+    el.borderHorizontal = el.borders[0];
+    el.borderVertical = el.borders[1];
+    el.borderParallel = el.borders[2];
+
+    //el.borderHorizontal.setArrow(false, {type: 2, size: 10});
+    //el.borderVertical.setArrow(false, {type: 2, size: 10});
+    el.borderParallel.setArrow(false, false);
 
     attr = Type.copyAttributes(attributes, board.options, "slopetriangle", 'label');
     //label = board.create("text", [
@@ -262,16 +266,18 @@ JXG.createSlopeTriangle = function (board, parents, attributes) {
     attr = Type.copyAttributes(attr, board.options, 'label');
     // Add label to vertical polygon edge
     attr.isLabel = true;
-    attr.anchor = el.borders[1];
-    attr.priv = el.borders[1].visProp.priv;
-    attr.id = el.borders[1].id + 'Label';
+    attr.anchor = el.borderVertical;
+    attr.priv = el.borderVertical.visProp.priv;
+    attr.id = el.borderVertical.id + 'Label';
 
     label = board.create("text", [0, 0, function () { return ""; }], attr);
     label.needsUpdate = true;
     label.dump = false;
-    el.borders[1].label = label;
-    el.borders[1].hasLabel = true;
-    el.borders[1].visProp.withlabel = true;
+    el.borderVertical.label = label;
+    el.borderVertical.hasLabel = true;
+    el.borderVertical.visProp.withlabel = true;
+
+    el.borderVertical.slopetriangle = el;
 
     label.setText(function () {
         var prefix = '',
@@ -328,6 +334,9 @@ JXG.createSlopeTriangle = function (board, parents, attributes) {
         basepoint: "basepoint",
         baseline: "baseline",
         toppoint: "toppoint",
+        borderHorizontal: "borderHorizontal",
+        borderVertical: "borderVertical",
+        borderParallel: "borderParallel",
         label: "label",
         Value: "Value",
         V: "Value",

--- a/src/options.js
+++ b/src/options.js
@@ -8905,7 +8905,74 @@ JXG.Options = {
          */
         label: {
             visible: true,
-            position: 'first'
+            position: 'first',
+
+            /**
+             * This specifies the unit of slope triangle in dimension 1 (e.g. length).
+             * Of course a slope has no dimension. But this value will be used to determ unit of horizontal and vertical length.
+             * If you want to use different units for each dimension, see {@link Slopetriangle#units}.
+             *
+             *
+             * @see Slopetriangle#units
+             * @name Slopetriangle#baseUnit
+             * @type String
+             * @default ''
+             */
+            baseUnit: '',
+
+            /**
+             * This attribute expects an object that has the dimension numbers as keys (as integer or in the form of 'dimxx')
+             * and assigns a string to each dimension.
+             * Of course a slope has no dimension. But this value will be used to determ unit of horizontal and vertical length.
+             * If a dimension has no specification, {@link Slopetriangle#baseUnit} is used.
+             *
+             * @see Slopetriangle#baseUnit
+             * @name Slopetriangle#units
+             * @type Object
+             * @default {}
+             */
+            units: {},
+
+            /**
+             * Determines whether a prefix is displayed before the slope triangle value and unit.
+             *
+             * @see Slopetriangle#prefix
+             * @name Slopetriangle#showPrefix
+             * @type Boolean
+             * @default false
+             */
+            showPrefix: true,
+
+            /**
+             * Determines whether a suffix is displayed after the slope triangle value and unit.
+             *
+             * @see Slopetriangle#suffix
+             * @name Slopetriangle#showSuffix
+             * @type Boolean
+             * @default false
+             */
+            showSuffix: true,
+
+            /**
+             * String that is displayed before the slope triangle and its unit.
+             *
+             * @see Slopetriangle#showPrefix
+             * @name Slopetriangle#prefix
+             * @type String
+             * @default ''
+             */
+            prefix: '',
+
+            /**
+             * String that is displayed after the slope triangle and its unit.
+             *
+             * @see Slopetriangle#showSuffix
+             * @name Slopetriangle#suffix
+             * @type String
+             * @default ''
+             */
+            suffix: ''
+
         }
         /**#@-*/
     },

--- a/src/options.js
+++ b/src/options.js
@@ -8907,73 +8907,105 @@ JXG.Options = {
             visible: true,
             position: 'first',
 
-            /**
-             * This specifies the unit of slope triangle in dimension 1 (e.g. length).
-             * Of course a slope has no dimension. But this value will be used to determ unit of horizontal and vertical length.
-             * If you want to use different units for each dimension, see {@link Slopetriangle#units}.
-             *
-             *
-             * @see Slopetriangle#units
-             * @name Slopetriangle#baseUnit
-             * @type String
-             * @default ''
-             */
-            baseUnit: '',
+            digits: function (self) {
+                return self.slopetriangle.evalVisProp('digits');
+            },
+            baseUnit: function (self) {
+                return self.slopetriangle.evalVisProp('baseUnit');
+            },
+            units: function (self) {
+                return self.slopetriangle.evalVisProp('units');
+            },
+            showPrefix: function (self) {
+                return self.slopetriangle.evalVisProp('showPrefix');
+            },
+            showSuffix: function (self) {
+                return self.slopetriangle.evalVisProp('showSuffix');
+            },
+            prefix: function (self) {
+                return self.slopetriangle.evalVisProp('prefix');
+            },
+            suffix: function (self) {
+                return self.slopetriangle.evalVisProp('suffix');
+            },
+        },
 
-            /**
-             * This attribute expects an object that has the dimension numbers as keys (as integer or in the form of 'dimxx')
-             * and assigns a string to each dimension.
-             * Of course a slope has no dimension. But this value will be used to determ unit of horizontal and vertical length.
-             * If a dimension has no specification, {@link Slopetriangle#baseUnit} is used.
-             *
-             * @see Slopetriangle#baseUnit
-             * @name Slopetriangle#units
-             * @type Object
-             * @default {}
-             */
-            units: {},
+        /**
+         * Used to round texts given by a number.
+         *
+         * @memberOf Slopetriangle.prototype
+         * @name digits
+         * @type Number
+         * @default 2
+         */
+        digits: 2,
 
-            /**
-             * Determines whether a prefix is displayed before the slope triangle value and unit.
-             *
-             * @see Slopetriangle#prefix
-             * @name Slopetriangle#showPrefix
-             * @type Boolean
-             * @default false
-             */
-            showPrefix: true,
+        /**
+         * This specifies the unit of slope triangle in dimension 1 (e.g. length).
+         * Of course a slope has no dimension. But this value will be used to determ unit of horizontal and vertical length.
+         * If you want to use different units for each dimension, see {@link Slopetriangle#units}.
+         *
+         *
+         * @see Slopetriangle#units
+         * @name Slopetriangle#baseUnit
+         * @type String
+         * @default ''
+         */
+        baseUnit: '',
 
-            /**
-             * Determines whether a suffix is displayed after the slope triangle value and unit.
-             *
-             * @see Slopetriangle#suffix
-             * @name Slopetriangle#showSuffix
-             * @type Boolean
-             * @default false
-             */
-            showSuffix: true,
+        /**
+         * This attribute expects an object that has the dimension numbers as keys (as integer or in the form of 'dimxx')
+         * and assigns a string to each dimension.
+         * Of course a slope has no dimension. But this value will be used to determ unit of horizontal and vertical length.
+         * If a dimension has no specification, {@link Slopetriangle#baseUnit} is used.
+         *
+         * @see Slopetriangle#baseUnit
+         * @name Slopetriangle#units
+         * @type Object
+         * @default {}
+         */
+        units: {},
 
-            /**
-             * String that is displayed before the slope triangle and its unit.
-             *
-             * @see Slopetriangle#showPrefix
-             * @name Slopetriangle#prefix
-             * @type String
-             * @default ''
-             */
-            prefix: '',
+        /**
+         * Determines whether a prefix is displayed before the slope triangle value and unit.
+         *
+         * @see Slopetriangle#prefix
+         * @name Slopetriangle#showPrefix
+         * @type Boolean
+         * @default false
+         */
+        showPrefix: true,
 
-            /**
-             * String that is displayed after the slope triangle and its unit.
-             *
-             * @see Slopetriangle#showSuffix
-             * @name Slopetriangle#suffix
-             * @type String
-             * @default ''
-             */
-            suffix: ''
+        /**
+         * Determines whether a suffix is displayed after the slope triangle value and unit.
+         *
+         * @see Slopetriangle#suffix
+         * @name Slopetriangle#showSuffix
+         * @type Boolean
+         * @default false
+         */
+        showSuffix: true,
 
-        }
+        /**
+         * String that is displayed before the slope triangle and its unit.
+         *
+         * @see Slopetriangle#showPrefix
+         * @name Slopetriangle#prefix
+         * @type String
+         * @default ''
+         */
+        prefix: '',
+
+        /**
+         * String that is displayed after the slope triangle and its unit.
+         *
+         * @see Slopetriangle#showSuffix
+         * @name Slopetriangle#suffix
+         * @type String
+         * @default ''
+         */
+        suffix: ''
+
         /**#@-*/
     },
 

--- a/src/options.js
+++ b/src/options.js
@@ -8970,7 +8970,7 @@ JXG.Options = {
             },
             suffix: function (self) {
                 return self.slopetriangle.evalVisProp('suffix');
-            },
+            }
         },
 
         /**

--- a/src/options.js
+++ b/src/options.js
@@ -8910,12 +8910,6 @@ JXG.Options = {
             digits: function (self) {
                 return self.slopetriangle.evalVisProp('digits');
             },
-            baseUnit: function (self) {
-                return self.slopetriangle.evalVisProp('baseUnit');
-            },
-            units: function (self) {
-                return self.slopetriangle.evalVisProp('units');
-            },
             showPrefix: function (self) {
                 return self.slopetriangle.evalVisProp('showPrefix');
             },
@@ -8939,32 +8933,6 @@ JXG.Options = {
          * @default 2
          */
         digits: 2,
-
-        /**
-         * This specifies the unit of slope triangle in dimension 1 (e.g. length).
-         * Of course a slope has no dimension. But this value will be used to determ unit of horizontal and vertical length.
-         * If you want to use different units for each dimension, see {@link Slopetriangle#units}.
-         *
-         *
-         * @see Slopetriangle#units
-         * @name Slopetriangle#baseUnit
-         * @type String
-         * @default ''
-         */
-        baseUnit: '',
-
-        /**
-         * This attribute expects an object that has the dimension numbers as keys (as integer or in the form of 'dimxx')
-         * and assigns a string to each dimension.
-         * Of course a slope has no dimension. But this value will be used to determ unit of horizontal and vertical length.
-         * If a dimension has no specification, {@link Slopetriangle#baseUnit} is used.
-         *
-         * @see Slopetriangle#baseUnit
-         * @name Slopetriangle#units
-         * @type Object
-         * @default {}
-         */
-        units: {},
 
         /**
          * Determines whether a prefix is displayed before the slope triangle value and unit.


### PR DESCRIPTION
Dear Alfred,

Essentially, this PR adds `prefix` and `suffix` to the label of slope triangles. The code follows the programming style used in “measurement”.

In addition, there are a few “links” within a slopetriangle object that shouldn't cause any issues, but are very helpful in sketchometry and JessieCode.

I’ve also added the ability for users to set attributes like `suffix`, `prefix`, and `digits` directly in the `slopetriangle` object, and the label will follow these settings. (This is backwards compatible.)

I’d appreciate your feedback. If the PR is accepted, the `slopetriangle` branch can be deleted.

Best regards,  
Andreas
