### PR TITLE
Improve elType

### DIFF
--- a/src/base/element.js
+++ b/src/base/element.js
@@ -1862,6 +1862,7 @@ JXG.extend(
                         ],
                         attr
                     );
+                    this.label.elType = 'label';
                     this.label.needsUpdate = true;
                     this.label.dump = false;
                     this.label.fullUpdate();

--- a/src/base/ticks.js
+++ b/src/base/ticks.js
@@ -1564,6 +1564,7 @@ JXG.extend(
                     label = JXG.createText(this.board, [ld.x, ld.y, ld.t], attr);
                     this.addChild(label);
                     label.setParents(this);
+                    label.elType = 'label';
                     label.isDraggable = false;
                     label.dump = false;
                     this.labels.push(label);

--- a/src/element/slopetriangle.js
+++ b/src/element/slopetriangle.js
@@ -182,6 +182,7 @@ JXG.createSlopeTriangle = function (board, parents, attributes) {
     attr = Type.copyAttributes(attributes, board.options, 'slopetriangle');
     // attr.borders = Type.copyAttributes(attr.borders, board.options, "slopetriangle", 'borders');
     el = board.create("polygon", [tglide, glider, toppoint], attr);
+    el.elType = 'slopetriangle';
 
     /**
      * Returns the value of the slope triangle, that is the slope of the tangent.

--- a/src/element/slopetriangle.js
+++ b/src/element/slopetriangle.js
@@ -231,6 +231,7 @@ JXG.createSlopeTriangle = function (board, parents, attributes) {
     attr.id = el.borders[1].id + 'Label';
 
     label = board.create("text", [0, 0, function () { return ""; }], attr);
+    label.elType = 'label';
     label.needsUpdate = true;
     label.dump = false;
     el.borders[1].label = label;

--- a/src/element/smartlabel.js
+++ b/src/element/smartlabel.js
@@ -466,6 +466,7 @@ JXG.createSmartLabel = function (board, parents, attributes) {
     }
 
     if (Type.exists(el)) {
+        el.elType = 'smartlabel';
         el.setText(txt_fun);
         p.addChild(el);
         el.setParents([p]);


### PR DESCRIPTION
Dear Alfred,

Unfortunately, it’s not always easy to distinguish between object types. That’s why I’ve defined different `elType`s for labels, smartlabels, and slopetriangles. Is this acceptable, or will it cause problems? How could I then distinguish these objects from others?

If the PR is accepted, the `dev_elTypes` branch can be deleted.

Best regards,  
Andreas