### PR TITLE
Transformations & twoFingerMove - part 2

### DIFF
--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1524,6 +1524,36 @@ JXG.extend(
         },
 
         /**
+         * Saves value in this.prevCoords, this.prevScale, this.prevDist and this.isPreviousGesture if the new values are not null.
+         * This is necessary for {@link JXG.Board.twoFingerPinch}.
+         *
+         * @param {Array|null} coords
+         * @param {Number|null} scale
+         * @param {Number|null} dist
+         * @param {String|null} gesture
+         * @see JXG.Board.twoFingerPinch
+         */
+        saveTwoFingerPinch: function (coords, scale, dist, gesture) {
+            if (Type.exists(coords)) {
+                this.prevCoords = coords;
+            }
+            if (Type.exists(scale)) {
+                this.prevScale = scale;
+            }
+            if (Type.exists(dist)) { // Android pinch to zoom
+                this.prevDist = dist;
+            }
+            this.saveTwoFingerGesture(gesture);
+        },
+
+        saveTwoFingerGesture: function (gesture) {
+            if (Type.exists(gesture)) {
+                this.isPreviousGesture = gesture;
+            }
+        },
+
+
+        /**
          * Moves elements in multitouch mode.
          * @param {Array} p1 x,y coordinates of first touch
          * @param {Array} p2 x,y coordinates of second touch
@@ -2585,7 +2615,7 @@ JXG.extend(
 
             if (this.attr.pan.enabled && this.attr.pan.needtwofingers && !isPinch) {
                 // Pan detected
-                this.isPreviousGesture = 'pan';
+                this.saveTwoFingerGesture('pan');
                 this.moveOrigin(c.scrCoords[1], c.scrCoords[2], true);
 
             } else if (this.attr.zoom.enabled && Math.abs(factor - 1.0) < 0.5) {
@@ -2650,18 +2680,19 @@ JXG.extend(
             var pos;
 
             evt.preventDefault();
-            this.prevScale = 1.0;
-            // Android pinch to zoom
-            this.prevDist = Geometry.distance(
-                [evt.touches[0].clientX, evt.touches[0].clientY],
-                [evt.touches[1].clientX, evt.touches[1].clientY],
-                2
+            this.saveTwoFingerPinch(
+                [ // coords
+                    [evt.touches[0].clientX, evt.touches[0].clientY],
+                    [evt.touches[1].clientX, evt.touches[1].clientY]
+                ],
+                1.0, // scale
+                Geometry.distance( // dist (Android pinch to zoom)
+                    [evt.touches[0].clientX, evt.touches[0].clientY],
+                    [evt.touches[1].clientX, evt.touches[1].clientY],
+                    2
+                ),
+                'none' // gesture
             );
-            this.prevCoords = [
-                [evt.touches[0].clientX, evt.touches[0].clientY],
-                [evt.touches[1].clientX, evt.touches[1].clientY]
-            ];
-            this.isPreviousGesture = 'none';
 
             // If pinch-to-zoom is interpreted as panning
             // we have to prepare move origin

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1524,30 +1524,42 @@ JXG.extend(
         },
 
         /**
-         * Saves values in this.prevCoords, this.prevScale, this.prevDist and this.isPreviousGesture
-         * if the new values are not null.
+         * Initializes this.prevCoords, this.prevScale, this.prevDist and this.isPreviousGesture.
          * This is necessary for {@link JXG.Board.twoFingerGesture}.
          *
-         * @param {Array|null} coords
-         * @param {Number|null} scale
-         * @param {Number|null} dist
-         * @param {String|null} gesture
+         * @param {Event} evt
          * @see JXG.Board.twoFingerGesture
-         * @see JXG.Board.saveTwoFingerGesture
+         * @see JXG.Board.pointerDownListener
+         * @see JXG.Board.touchStartListener
+         * @see JXG.Board.gestureStartListener
+         *
+         * @private
          */
-        saveTwoFingerPinch: function (coords, scale, dist, gesture) {
-            if (Type.exists(coords)) {
-                this.prevCoords = coords;
+        twoFingerGestureStart: function (evt) {
+            if (!Type.exists(evt.touches) ||
+                evt.touches.length < 2) {
+                delete this.prevCoords;
+                delete this.prevScale;
+                this.prevDist = 1;
+                this.isPreviousGesture = 'none';
+                return;
             }
-            if (Type.exists(scale)) {
-                this.prevScale = scale;
-            }
-            if (Type.exists(dist)) { // Android pinch to zoom
-                this.prevDist = dist;
-            }
-            if (Type.exists(gesture)) {
-                this.isPreviousGesture = gesture;
-            }
+
+            this.prevCoords = [
+                [evt.touches[0].clientX, evt.touches[0].clientY],
+                [evt.touches[1].clientX, evt.touches[1].clientY]
+            ];
+
+            this.prevScale = 1.0;
+
+            // Android pinch to zoom
+            this.prevDist = Geometry.distance(
+                [evt.touches[0].clientX, evt.touches[0].clientY],
+                [evt.touches[1].clientX, evt.touches[1].clientY],
+                2
+            );
+
+            this.isPreviousGesture = 'none';
         },
 
         /**
@@ -1562,6 +1574,7 @@ JXG.extend(
          *     <li>{Number} dist</li>
          *     <li>{Number} angle</li>
          *     </ul>
+         * @see JXG.Board.twoFingerGestureStart
          * @see JXG.Board.gestureChangeListener
          * @see JXG.Board.twoFingerTouchObject
          */
@@ -1627,13 +1640,11 @@ JXG.extend(
 
             factor = evt.scale / this.prevScale;
 
-            this.saveTwoFingerPinch(
-                [ // coords
-                    [evt.touches[0].clientX, evt.touches[0].clientY],
-                    [evt.touches[1].clientX, evt.touches[1].clientY]
-                ],
-                evt.scale // scale
-            );
+            this.prevCoords = [
+                [evt.touches[0].clientX, evt.touches[0].clientY],
+                [evt.touches[1].clientX, evt.touches[1].clientY]
+            ];
+            this.prevScale = evt.scale;
 
             return {
                 isPinch: isPinch,
@@ -2724,19 +2735,10 @@ JXG.extend(
             var pos;
 
             evt.preventDefault();
-            this.saveTwoFingerPinch(
-                [ // coords
-                    [evt.touches[0].clientX, evt.touches[0].clientY],
-                    [evt.touches[1].clientX, evt.touches[1].clientY]
-                ],
-                1.0, // scale
-                Geometry.distance( // dist (Android pinch to zoom)
-                    [evt.touches[0].clientX, evt.touches[0].clientY],
-                    [evt.touches[1].clientX, evt.touches[1].clientY],
-                    2
-                ),
-                'none' // gesture
-            );
+
+            // If we use alleGestures, gestureStartListener is calles directly.
+            // So we have to initialize (again).
+            this.twoFingerGestureStart(evt);
 
             // If pinch-to-zoom is interpreted as panning
             // we have to prepare move origin
@@ -3084,18 +3086,21 @@ JXG.extend(
                 ) {
                     // Empty by purpose
                 } else if (
-                    evt.touches.length === 2 &&
-                    (this.mode === this.BOARD_MODE_NONE ||
-                        this.mode === this.BOARD_MODE_MOVE_ORIGIN)
+                    evt.touches.length === 2
                 ) {
-                    // 2. case: two fingers: pinch to zoom or pan with two fingers needed.
-                    // This happens when the second finger hits the device. First, the
-                    // 'one finger pan mode' has to be cancelled.
-                    if (this.mode === this.BOARD_MODE_MOVE_ORIGIN) {
-                        this.originMoveEnd();
-                    }
+                    // 2. case: two fingers.
+                    // Pinch or pan with two fingers for zoom or manupulating objects.
+                    this.twoFingerGestureStart(evt);
 
-                    this.gestureStartListener(evt);
+                    if( this.mode === this.BOARD_MODE_NONE ||
+                        this.mode === this.BOARD_MODE_MOVE_ORIGIN) {
+                        // This happens when the second finger hits the device. First, the
+                        // 'one finger pan mode' has to be cancelled.
+                        if (this.mode === this.BOARD_MODE_MOVE_ORIGIN) {
+                            this.originMoveEnd();
+                        }
+                        this.gestureStartListener(evt);
+                    }
                 }
             }
 
@@ -3703,13 +3708,19 @@ JXG.extend(
                 (this.mode === this.BOARD_MODE_NONE ||
                     this.mode === this.BOARD_MODE_MOVE_ORIGIN)
             ) {
-                // 2. case: two fingers: pinch to zoom or pan with two fingers needed.
-                // This happens when the second finger hits the device. First, the
-                // 'one finger pan mode' has to be cancelled.
-                if (this.mode === this.BOARD_MODE_MOVE_ORIGIN) {
-                    this.originMoveEnd();
+                // 2. case: two fingers.
+                // Pinch or pan with two fingers for zoom or manupulating objects.
+                this.twoFingerGestureStart(evt);
+
+                if( this.mode === this.BOARD_MODE_NONE ||
+                    this.mode === this.BOARD_MODE_MOVE_ORIGIN) {
+                    // This happens when the second finger hits the device. First, the
+                    // 'one finger pan mode' has to be cancelled.
+                    if (this.mode === this.BOARD_MODE_MOVE_ORIGIN) {
+                        this.originMoveEnd();
+                    }
+                    this.gestureStartListener(evt);
                 }
-                this.gestureStartListener(evt);
             }
 
             this.options.precision.hasPoint = this.options.precision.mouse;

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1809,18 +1809,12 @@ JXG.extend(
          *     </ul>
          */
         getTwoFingerTransforms: function (finger1, finger2, scalable, rotatable, evt) {
-            var gesture,
-                crd,
+            var crd,
                 x1, y1, x2, y2,
                 dx, dy,
                 xx1, yy1, xx2, yy2,
                 dxx, dyy,
                 C, S, LL, tx, ty, lbda;
-
-            gesture = this.twoFingerGesture(evt);
-            if (Type.isEmpty(gesture)) {
-                return false;
-            }
 
             crd = new Coords(Const.COORDS_BY_SCREEN, [finger1.Xprev, finger1.Yprev], this).usrCoords;
             x1 = crd[1];
@@ -1871,7 +1865,7 @@ JXG.extend(
                 ],
 
                 twofingers: [
-                    tx,ty,
+                    tx, ty,
                     lbda,
                     Math.atan2(S, C)
                 ],

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1568,7 +1568,8 @@ JXG.extend(
          * @param {Event} evt
          * @param {Boolean} [allowPan=true]
          * @param {Number} [pinchDirSensitivity=5] Sensitivity (in degrees) for recognizing horizontal or vertical pinch gestures.
-         * @returns {Object} <ul>
+         * @param {Boolean} [filterSmallMovements=false]
+         * @returns {Object|null} <ul>
          *     <li>{Boolean} isPinch</li>
          *     <li>{Boolean} isPinchVertical</li>
          *     <li>{Boolean} isPinchHorizontal</li>
@@ -1585,11 +1586,12 @@ JXG.extend(
          *     <li>{Number} dx Distance between finger 1 and 2 (x direction)</li>
          *     <li>{Number} dy Distance between finger 1 and 2 (y direction)</li>
          *     </ul>
+         *     In case of an error or early exit (filterSmallMovements) the return is null.
          * @see JXG.Board.twoFingerGestureStart
          * @see JXG.Board.gestureChangeListener
          * @see JXG.Board.twoFingerTouchObject
          */
-        twoFingerGesture: function (evt, allowPan, pinchDirSensitivity) {
+        twoFingerGesture: function (evt, allowPan, pinchDirSensitivity, filterSmallMovements) {
             var mi = 10,
                 dir1, dir2,
                 movementAngle,
@@ -1604,9 +1606,12 @@ JXG.extend(
             if (!Type.exists(this.prevCoords) ||
                 !Type.exists(evt.touches) ||
                 evt.touches.length < 2) {
-                return {};
+                return null;
             }
 
+            if (!Type.exists(filterSmallMovements)) {
+                filterSmallMovements = false;
+            }
             if (!Type.exists(allowPan)) {
                 allowPan = true;
             }
@@ -1640,10 +1645,11 @@ JXG.extend(
             ];
 
             if (
+                filterSmallMovements &&
                 dir1[0] * dir1[0] + dir1[1] * dir1[1] < mi * mi &&
                 dir2[0] * dir2[0] + dir2[1] * dir2[1] < mi * mi
             ) {
-                return {}; // too small movement of fingers
+                return null; // too small movement of fingers
             }
 
             // Compute the angle of the two finger directions
@@ -2713,9 +2719,10 @@ JXG.extend(
             gesture = this.twoFingerGesture(
                 evt,
                 this.attr.pan.enabled && this.attr.pan.needtwofingers,
-                this.attr.zoom.pinchsensitivity
+                this.attr.zoom.pinchsensitivity,
+                true
             );
-            if (Type.isEmpty(gesture)) {
+            if (!Type.exists(gesture)) {
                 return false;
             }
 

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -2708,9 +2708,8 @@ JXG.extend(
                 // Save zoomFactors
                 zx = this.attr.zoom.factorx,
                 zy = this.attr.zoom.factory,
-                zoomCenter,
-                doZoom = false,
-                cx, cy;
+                zoomCenter, cx, cy,
+                doZoom = false;
 
             if (this.mode !== this.BOARD_MODE_ZOOM) {
                 return true;
@@ -2728,7 +2727,7 @@ JXG.extend(
 
             if (gesture.isPan && !gesture.isPinch) {
                 // Pan detected
-                this.moveOrigin(gesture.p1.scrCoords[1], gesture.p1.scrCoords[2], true);
+                this.moveOrigin(gesture.center.scrCoords[1], gesture.center.scrCoords[2], true);
 
             } else if (this.attr.zoom.enabled && gesture.isPinch && Math.abs(gesture.factor - 1.0) < 0.5) {
                 // Pinch detected
@@ -2758,15 +2757,23 @@ JXG.extend(
                 } else if (this.attr.zoom.pinch) {
                     this.attr.zoom.factorx = gesture.factor;
                     this.attr.zoom.factory = gesture.factor;
-                    cx = gesture.p1.usrCoords[1];
-                    cy = gesture.p1.usrCoords[2];
+                    if (zoomCenter === 'auto' || zoomCenter === 'center') {
+                        cx = gesture.center.usrCoords[1];
+                        cy = gesture.center.usrCoords[2];
+                    } else if (zoomCenter === 'first') {
+                        cx = gesture.p1.usrCoords[1];
+                        cy = gesture.p1.usrCoords[2];
+                    } else if (zoomCenter === 'second') {
+                        cx = gesture.p2.usrCoords[1];
+                        cy = gesture.p2.usrCoords[2];
+                    }
                     doZoom = true;
                 }
 
                 if (doZoom) {
                     if (zoomCenter === 'board') {
                         this.zoomIn();
-                    } else { // including zoomCenter === 'auto'
+                    } else { // including zoomCenter === 'auto', 'first', 'second'
                         this.zoomIn(cx, cy);
                     }
 
@@ -4278,7 +4285,7 @@ JXG.extend(
 
             if (zoomCenter === 'board') {
                 pos = [];
-            } else { // including zoomCenter === 'auto'
+            } else { // including zoomCenter === 'auto', 'first', 'second'
                 pos = new Coords(Const.COORDS_BY_SCREEN, this.getMousePosition(evt), this).usrCoords;
             }
 

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1526,13 +1526,13 @@ JXG.extend(
         /**
          * Saves values in this.prevCoords, this.prevScale, this.prevDist and this.isPreviousGesture
          * if the new values are not null.
-         * This is necessary for {@link JXG.Board.twoFingerPinch}.
+         * This is necessary for {@link JXG.Board.twoFingerGesture}.
          *
          * @param {Array|null} coords
          * @param {Number|null} scale
          * @param {Number|null} dist
          * @param {String|null} gesture
-         * @see JXG.Board.twoFingerPinch
+         * @see JXG.Board.twoFingerGesture
          * @see JXG.Board.saveTwoFingerGesture
          */
         saveTwoFingerPinch: function (coords, scale, dist, gesture) {
@@ -1550,10 +1550,10 @@ JXG.extend(
 
         /**
          * Saves value in this.isPreviousGesture if it exists.
-         * This is necessary for {@link JXG.Board.twoFingerPinch}.
+         * This is necessary for {@link JXG.Board.twoFingerGesture}.
          *
          * @param {String|null} value
-         * @see JXG.Board.twoFingerPinch
+         * @see JXG.Board.twoFingerGesture
          * @see JXG.Board.saveTwoFingerGesture
          */
         saveTwoFingerGesture: function (value) {
@@ -1577,7 +1577,7 @@ JXG.extend(
          * @see JXG.Board.gestureChangeListener
          * @see JXG.Board.twoFingerTouchObject
          */
-        twoFingerPinch: function (evt) {
+        twoFingerGesture: function (evt) {
             var mi = 10,
                 dir1 = [],
                 dir2 = [],
@@ -1754,7 +1754,7 @@ JXG.extend(
          *     </ul>
          */
         getTwoFingerTransforms: function (finger1, finger2, scalable, rotatable, evt) {
-            var pinch,
+            var gesture,
                 crd,
                 x1, y1, x2, y2,
                 dx, dy,
@@ -1762,8 +1762,8 @@ JXG.extend(
                 dxx, dyy,
                 C, S, LL, tx, ty, lbda;
 
-            pinch = this.twoFingerPinch(evt);
-           // console.log(pinch);
+            gesture = this.twoFingerGesture(evt);
+            // console.log(gesture);
 
             crd = new Coords(Const.COORDS_BY_SCREEN, [finger1.Xprev, finger1.Yprev], this).usrCoords;
             x1 = crd[1];
@@ -2647,8 +2647,8 @@ JXG.extend(
          * @returns {Boolean}
          */
         gestureChangeListener: function (evt) {
-            var c,
-                pinch,
+            var gesture,
+                c,
                 // Save zoomFactors
                 zx = this.attr.zoom.factorx,
                 zy = this.attr.zoom.factory,
@@ -2662,19 +2662,19 @@ JXG.extend(
             }
             evt.preventDefault();
 
-            pinch = this.twoFingerPinch(evt);
-            if (Type.isEmpty(pinch)) {
+            gesture = this.twoFingerGesture(evt);
+            if (Type.isEmpty(gesture)) {
                 return false;
             }
 
             c = new Coords(Const.COORDS_BY_SCREEN, this.getMousePosition(evt, 0), this);
 
-            if (this.attr.pan.enabled && this.attr.pan.needtwofingers && !pinch.isPinch) {
+            if (this.attr.pan.enabled && this.attr.pan.needtwofingers && !gesture.isPinch) {
                 // Pan detected
                 this.saveTwoFingerGesture('pan');
                 this.moveOrigin(c.scrCoords[1], c.scrCoords[2], true);
 
-            } else if (this.attr.zoom.enabled && Math.abs(pinch.factor - 1.0) < 0.5) {
+            } else if (this.attr.zoom.enabled && Math.abs(gesture.factor - 1.0) < 0.5) {
                 doZoom = false;
                 zoomCenter = this.attr.zoom.center;
                 // Pinch detected
@@ -2698,13 +2698,13 @@ JXG.extend(
                     Math.abs(theta - Math.PI * 0.5) < bound
                 ) {
                     this.attr.zoom.factorx = 1.0;
-                    this.attr.zoom.factory = pinch.factor;
+                    this.attr.zoom.factory = gesture.factor;
                     cx = 0;
                     cy = 0;
                     doZoom = true;
                 } else if (this.attr.zoom.pinch) {
-                    this.attr.zoom.factorx = pinch.factor;
-                    this.attr.zoom.factory = pinch.factor;
+                    this.attr.zoom.factorx = gesture.factor;
+                    this.attr.zoom.factory = gesture.factor;
                     cx = c.usrCoords[1];
                     cy = c.usrCoords[2];
                     doZoom = true;

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -3241,6 +3241,12 @@ JXG.extend(
                     [evt, this.mode]
                 );
             } else if (!this.mouseOriginMove(evt)) {
+
+                if (this._getPointerInputDevice(evt) === 'touch') {
+                    this._pointerStorePosition(evt);
+                    evt.touches = this._board_touches;
+                }
+
                 if (this.mode === this.BOARD_MODE_DRAG) {
                     // Run through all jsxgraph elements which are touched by at least one finger.
                     for (i = 0; i < this.touches.length; i++) {
@@ -3268,13 +3274,8 @@ JXG.extend(
                         }
                     }
                 } else {
-                    if (this._getPointerInputDevice(evt) === 'touch') {
-                        this._pointerStorePosition(evt);
-
-                        if (this._board_touches.length === 2) {
-                            evt.touches = this._board_touches;
-                            this.gestureChangeListener(evt);
-                        }
+                    if (this._getPointerInputDevice(evt) === 'touch' && this._board_touches.length === 2) {
+                        this.gestureChangeListener(evt);
                     }
 
                     // Move event without dragging an element

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1708,7 +1708,7 @@ JXG.extend(
 
                 dist: dist,
                 dx: dx,
-                dy: dy,
+                dy: dy
             };
         },
 

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1608,7 +1608,6 @@ JXG.extend(
          * @param {Object} finger2 Actual and previous position of finger 2
          * @param {Boolean} scalable Flag if element may be scaled
          * @param {Boolean} rotatable Flag if element may be rotated
-         * @param {Event} evt The event object that lead to this movement.
          * @returns {Object} Transformation parameters <ul>
          *     <li><tt>{Array} generic</tt> Array of length 9</li>
          *     <li><tt>{Array} affine</tt> Array of length 6</li>
@@ -1620,7 +1619,7 @@ JXG.extend(
          *     </ul></li>
          *     </ul>
          */
-        getTwoFingerTransforms: function (finger1, finger2, scalable, rotatable, evt) {
+        getTwoFingerTransforms: function (finger1, finger2, scalable, rotatable) {
             var gesture,
                 crd,
                 x1, y1, x2, y2,
@@ -1628,11 +1627,6 @@ JXG.extend(
                 xx1, yy1, xx2, yy2,
                 dxx, dyy,
                 C, S, LL, tx, ty, lbda;
-
-            gesture = this.twoFingerGesture(evt);
-            if (Type.isEmpty(gesture)) {
-                return false;
-            }
 
             crd = new Coords(Const.COORDS_BY_SCREEN, [finger1.Xprev, finger1.Yprev], this).usrCoords;
             x1 = crd[1];
@@ -1742,11 +1736,12 @@ JXG.extend(
                 !isNaN(tar[0].Xprev + tar[0].Yprev + tar[1].Xprev + tar[1].Yprev)
             ) {
 
-                T = this.getTwoFingerTransform(
+                T = this.getTwoFingerTransforms(
                     tar[0], tar[1],
                     drag.evalVisProp('scalable'),
-                    drag.evalVisProp('rotatable'));
-                t = this.create('transform', T, { type: 'generic' });
+                    drag.evalVisProp('rotatable')
+                );
+                t = this.create('transform', T.twofingers, {type: 'twofingers'});
                 t.update();
 
                 if (drag.elementClass === Const.OBJECT_CLASS_LINE) {

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1567,9 +1567,8 @@ JXG.extend(
          *
          * @param {Event} evt
          * @param {Number} [pinchDirSensitivity=5] Sensitivity (in degrees) for recognizing horizontal or vertical pinch gestures.
+         * @param {Boolean} [stayPinchXY=false]
          * @param {Boolean} [allowPan=true]
-         * @param {Boolean} [panPinchExclusive=true]
-         * @param {Boolean} [filterSmallMovements=false]
          * @returns {Object|null} <ul>
          *     <li>{Boolean} isPinch</li>
          *     <li>{Boolean} isPinchVertical</li>
@@ -1592,7 +1591,7 @@ JXG.extend(
          * @see JXG.Board.gestureChangeListener
          * @see JXG.Board.twoFingerTouchObject
          */
-        twoFingerGesture: function (evt, pinchDirSensitivity, allowPan, panPinchExclusive, filterSmallMovements) {
+        twoFingerGesture: function (evt, pinchDirSensitivity,  stayPinchXY, allowPan) {
             var mi = 10,
                 dir1, dir2,
                 movementAngle,
@@ -1610,14 +1609,11 @@ JXG.extend(
                 return null;
             }
 
-            if (!Type.exists(filterSmallMovements)) {
-                filterSmallMovements = false;
-            }
             if (!Type.exists(allowPan)) {
                 allowPan = true;
             }
-            if (!Type.exists(panPinchExclusive)) {
-                panPinchExclusive = true;
+            if (!Type.exists(stayPinchXY)) {
+                stayPinchXY = false;
             }
             if (!Type.exists(pinchDirSensitivity)) {
                 pinchDirSensitivity = 5;
@@ -1649,7 +1645,6 @@ JXG.extend(
             ];
 
             if (
-                filterSmallMovements &&
                 dir1[0] * dir1[0] + dir1[1] * dir1[1] < mi * mi &&
                 dir2[0] * dir2[0] + dir2[1] * dir2[1] < mi * mi
             ) {
@@ -1657,12 +1652,12 @@ JXG.extend(
             }
 
             // Compute the angle of the two finger directions
-            movementAngle = Geometry.rad(dir1, [0, 0], dir2);
+            movementAngle = Math.abs(Geometry.rad(dir1, [0, 0], dir2));
 
             if (this.isPreviousGesture !== 'pan') {
                 if (
-                    Math.abs(movementAngle) > Math.PI * 0.2 &&
-                    Math.abs(movementAngle) < Math.PI * 1.8
+                    movementAngle > Math.PI * 0.2 &&
+                    movementAngle < Math.PI * 1.8
                 ) {
                     isPinch = true;
                 }
@@ -1672,14 +1667,25 @@ JXG.extend(
                 ) {
                     isPinch = true;
                 }
-                if (isPinch) {
+                if (
+                    isPinch ||
+                    (stayPinchXY && (this.isPreviousGesture === 'scaleX' || this.isPreviousGesture === 'scaleY'))
+                ) {
+                    isPinch = true;
+                    isPinchHorizontal =  this.isPreviousGesture === 'scaleX' || fingerLineAngle < pinchDirSensitivity;
+                    isPinchVertical = this.isPreviousGesture === 'scaleY' || Math.abs(fingerLineAngle - Math.PI * 0.5) < pinchDirSensitivity;
+
                     factor = evt.scale / this.prevScale;
-                    isPinchHorizontal = fingerLineAngle < pinchDirSensitivity;
-                    isPinchVertical = Math.abs(fingerLineAngle - Math.PI * 0.5) < pinchDirSensitivity;
+                }
+                if (isPinchHorizontal && stayPinchXY) {
+                    this.isPreviousGesture = 'scaleX';
+                }
+                if (isPinchVertical && stayPinchXY) {
+                    this.isPreviousGesture = 'scaleY';
                 }
             }
 
-            isPan = allowPan && (panPinchExclusive ? !isPinch : true);
+            isPan = allowPan && !isPinch;
 
             this.prevCoords = [p1, p2];
             this.prevScale = evt.scale;

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1566,26 +1566,40 @@ JXG.extend(
          * Gives information about a two finger gesture.
          *
          * @param {Event} evt
+         * @param {Boolean} [allowPan=true]
+         * @param {Number} [pinchDirSensitivity=5] Sensitivity (in degrees) for recognizing horizontal or vertical pinch gestures.
          * @returns {Object} <ul>
          *     <li>{Boolean} isPinch</li>
-         *     <li>{Number} factor</li>
+         *     <li>{Boolean} isPinchVertical</li>
+         *     <li>{Boolean} isPinchHorizontal</li>
+         *     <li>{Boolean} isPan</li>
          *     <li>{Array} dir1</li>
          *     <li>{Array} dir2</li>
+         *     <li>{Number} movementAngle (in Radians)</li>
+         *     <li>{Number} factor</li>
+         *     <li>{Number} dx</li>
+         *     <li>{Number} dy</li>
+         *     <li>{Number} fingerLineAngle</li>
+         *     <li>{JXG.Coords} center</li>
+         *     <li>{JXG.Coords} p1</li>
+         *     <li>{JXG.Coords} p2</li>
          *     <li>{Number} dist</li>
-         *     <li>{Number} angle</li>
          *     </ul>
          * @see JXG.Board.twoFingerGestureStart
          * @see JXG.Board.gestureChangeListener
          * @see JXG.Board.twoFingerTouchObject
          */
-        twoFingerGesture: function (evt) {
+        twoFingerGesture: function (evt, allowPan, pinchDirSensitivity) {
             var mi = 10,
-                dir1 = [],
-                dir2 = [],
-                angle,
-                factor,
-                dist,
-                isPinch = false;
+                dir1, dir2,
+                movementAngle,
+                dist, dx, dy, fingerLineAngle,
+                factor = 0,
+                p1, p2, center,
+                isPinchVertical = false,
+                isPinchHorizontal = false,
+                isPinch = false,
+                isPan = false;
 
             if (!Type.exists(this.prevCoords) ||
                 !Type.exists(evt.touches) ||
@@ -1593,11 +1607,35 @@ JXG.extend(
                 return {};
             }
 
+            if (!Type.exists(allowPan)) {
+                allowPan = true;
+            }
+            if (!Type.exists(pinchDirSensitivity)) {
+                pinchDirSensitivity = 5;
+            }
+            pinchDirSensitivity = (Math.PI * pinchDirSensitivity) / 90.0;
+
+            p1 = this.getMousePosition(evt, 0);
+            p2 = this.getMousePosition(evt, 1);
+            center = new Coords(
+                Const.COORDS_BY_SCREEN,
+                [
+                    0.5 * (p1[0] + p2[0]),
+                    0.5 * (p1[1] + p2[1])
+                ],
+                this
+            );
+            p1 = new Coords(Const.COORDS_BY_SCREEN, p1, this);
+            p2 = new Coords(Const.COORDS_BY_SCREEN, p2, this);
+
             dist = Geometry.distance(
                 [evt.touches[0].clientX, evt.touches[0].clientY],
                 [evt.touches[1].clientX, evt.touches[1].clientY],
                 2
             );
+            dx = Math.abs(evt.touches[0].clientX - evt.touches[1].clientX);
+            dy = Math.abs(evt.touches[0].clientY - evt.touches[1].clientY);
+            fingerLineAngle = Math.abs(Math.atan2(dy, dx));
 
             // Android pinch to zoom
             // evt.scale was available in iOS touch events (pre iOS 13)
@@ -1606,7 +1644,6 @@ JXG.extend(
                 evt.scale = dist / this.prevDist;
             }
 
-            // Compute the angle of the two finger directions
             dir1 = [
                 evt.touches[0].clientX - this.prevCoords[0][0],
                 evt.touches[0].clientY - this.prevCoords[0][1]
@@ -1620,39 +1657,63 @@ JXG.extend(
                 dir1[0] * dir1[0] + dir1[1] * dir1[1] < mi * mi &&
                 dir2[0] * dir2[0] + dir2[1] * dir2[1] < mi * mi
             ) {
-                return {}; // too small movement
+                return {}; // too small movement of fingers
             }
 
-            angle = Geometry.rad(dir1, [0, 0], dir2);
-            if (
-                this.isPreviousGesture !== 'pan' &&
-                Math.abs(angle) > Math.PI * 0.2 &&
-                Math.abs(angle) < Math.PI * 1.8
-            ) {
-                isPinch = true;
-            }
+            // Compute the angle of the two finger directions
+            movementAngle = Geometry.rad(dir1, [0, 0], dir2);
 
-            if (this.isPreviousGesture !== 'pan' && !isPinch) {
-                if (Math.abs(evt.scale) < 0.77 || Math.abs(evt.scale) > 1.3) {
+            if (this.isPreviousGesture !== 'pan') {
+                if (
+                    Math.abs(movementAngle) > Math.PI * 0.2 &&
+                    Math.abs(movementAngle) < Math.PI * 1.8
+                ) {
                     isPinch = true;
+                }
+                if (
+                    !isPinch && // fallback
+                    (Math.abs(evt.scale) < 0.77 || Math.abs(evt.scale) > 1.3)
+                ) {
+                    isPinch = true;
+                }
+                if (isPinch) {
+                    factor = evt.scale / this.prevScale;
+                    isPinchHorizontal = fingerLineAngle < pinchDirSensitivity;
+                    isPinchVertical = Math.abs(fingerLineAngle - Math.PI * 0.5) < pinchDirSensitivity;
                 }
             }
 
-            factor = evt.scale / this.prevScale;
+            isPan = allowPan && !isPinch;
 
             this.prevCoords = [
                 [evt.touches[0].clientX, evt.touches[0].clientY],
                 [evt.touches[1].clientX, evt.touches[1].clientY]
             ];
             this.prevScale = evt.scale;
+            if (isPan) {
+                // if pan is detected once, stay to pan
+                this.isPreviousGesture = 'pan';
+            }
 
             return {
                 isPinch: isPinch,
-                factor: factor,
+                isPinchVertical: isPinchVertical,
+                isPinchHorizontal: isPinchHorizontal,
+                isPan: isPan,
+
                 dir1: dir1,
                 dir2: dir2,
+                movementAngle: movementAngle,
+
+                factor: factor,
+                dx: dx,
+                dy: dy,
+
+                fingerLineAngle: fingerLineAngle,
+                center: center,
+                p1: p1,
+                p2: p2,
                 dist: dist,
-                angle: angle
             };
         },
 
@@ -1762,7 +1823,9 @@ JXG.extend(
                 C, S, LL, tx, ty, lbda;
 
             gesture = this.twoFingerGesture(evt);
-            // console.log(gesture);
+            if (Type.isEmpty(gesture)) {
+                return false;
+            }
 
             crd = new Coords(Const.COORDS_BY_SCREEN, [finger1.Xprev, finger1.Yprev], this).usrCoords;
             x1 = crd[1];
@@ -2647,54 +2710,50 @@ JXG.extend(
          */
         gestureChangeListener: function (evt) {
             var gesture,
-                c,
                 // Save zoomFactors
                 zx = this.attr.zoom.factorx,
                 zy = this.attr.zoom.factory,
-                theta, bound,
                 zoomCenter,
                 doZoom = false,
-                dx, dy, cx, cy;
+                cx, cy;
 
             if (this.mode !== this.BOARD_MODE_ZOOM) {
                 return true;
             }
             evt.preventDefault();
 
-            gesture = this.twoFingerGesture(evt);
+            gesture = this.twoFingerGesture(
+                evt,
+                this.attr.pan.enabled && this.attr.pan.needtwofingers,
+                this.attr.zoom.pinchsensitivity
+            );
             if (Type.isEmpty(gesture)) {
                 return false;
             }
 
-            c = new Coords(Const.COORDS_BY_SCREEN, this.getMousePosition(evt, 0), this);
-
-            if (this.attr.pan.enabled && this.attr.pan.needtwofingers && !gesture.isPinch) {
+            if (gesture.isPan && !gesture.isPinch) {
                 // Pan detected
-                this.isPreviousGesture = 'pan';
-                this.moveOrigin(c.scrCoords[1], c.scrCoords[2], true);
+                this.moveOrigin(gesture.p1.scrCoords[1], gesture.p1.scrCoords[2], true);
 
-            } else if (this.attr.zoom.enabled && Math.abs(gesture.factor - 1.0) < 0.5) {
+            } else if (this.attr.zoom.enabled && gesture.isPinch && Math.abs(gesture.factor - 1.0) < 0.5) {
+                // Pinch detected
                 doZoom = false;
                 zoomCenter = this.attr.zoom.center;
-                // Pinch detected
-                if (this.attr.zoom.pinchhorizontal || this.attr.zoom.pinchvertical) {
-                    dx = Math.abs(evt.touches[0].clientX - evt.touches[1].clientX);
-                    dy = Math.abs(evt.touches[0].clientY - evt.touches[1].clientY);
-                    theta = Math.abs(Math.atan2(dy, dx));
-                    bound = (Math.PI * this.attr.zoom.pinchsensitivity) / 90.0;
-                }
 
-                if (!this.keepaspectratio &&
+                if (
+                    !this.keepaspectratio &&
                     this.attr.zoom.pinchhorizontal &&
-                    theta < bound) {
-                    this.attr.zoom.factorx = pinch.factor;
+                    gesture.isPinchHorizontal
+                ) {
+                    this.attr.zoom.factorx = gesture.factor;
                     this.attr.zoom.factory = 1.0;
                     cx = 0;
                     cy = 0;
                     doZoom = true;
-                } else if (!this.keepaspectratio &&
+                } else if (
+                    !this.keepaspectratio &&
                     this.attr.zoom.pinchvertical &&
-                    Math.abs(theta - Math.PI * 0.5) < bound
+                    gesture.isPinchVertical
                 ) {
                     this.attr.zoom.factorx = 1.0;
                     this.attr.zoom.factory = gesture.factor;
@@ -2704,8 +2763,8 @@ JXG.extend(
                 } else if (this.attr.zoom.pinch) {
                     this.attr.zoom.factorx = gesture.factor;
                     this.attr.zoom.factory = gesture.factor;
-                    cx = c.usrCoords[1];
-                    cy = c.usrCoords[2];
+                    cx = gesture.p1.usrCoords[1];
+                    cy = gesture.p1.usrCoords[2];
                     doZoom = true;
                 }
 

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1540,6 +1540,7 @@ JXG.extend(
             }
 
             if (
+                drag.elementClass === Const.OBJECT_CLASS_CURVE ||
                 drag.elementClass === Const.OBJECT_CLASS_LINE ||
                 drag.type === Const.OBJECT_TYPE_POLYGON
             ) {
@@ -1663,6 +1664,8 @@ JXG.extend(
                         }
                         t.applyOnce(ar);
                     }
+                } else if (drag.elementClass === Const.OBJECT_CLASS_CURVE) {
+                    t.meltTo(drag);
                 }
 
                 this.update();

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1573,17 +1573,17 @@ JXG.extend(
          *     <li>{Boolean} isPinchVertical</li>
          *     <li>{Boolean} isPinchHorizontal</li>
          *     <li>{Boolean} isPan</li>
-         *     <li>{Array} dir1</li>
-         *     <li>{Array} dir2</li>
-         *     <li>{Number} movementAngle (in Radians)</li>
-         *     <li>{Number} factor</li>
-         *     <li>{Number} dx</li>
-         *     <li>{Number} dy</li>
-         *     <li>{Number} fingerLineAngle</li>
-         *     <li>{JXG.Coords} center</li>
-         *     <li>{JXG.Coords} p1</li>
-         *     <li>{JXG.Coords} p2</li>
-         *     <li>{Number} dist</li>
+         *     <li>{Array} dir1 Movement of finger 1 (respecting previous position)</li>
+         *     <li>{Array} dir2 Movement of finger 2 (respecting previous position)</li>
+         *     <li>{Number} movementAngle Angle of the two finger directions (in Radians)</li>
+         *     <li>{Number} factor Pinching factor.</li>
+         *     <li>{Number} fingerLineAngle Angle of the line between finger 1 and 2.</li>
+         *     <li>{JXG.Coords} center Position between finger 1 and 2.</li>
+         *     <li>{JXG.Coords} f1 Position of finger 1.</li>
+         *     <li>{JXG.Coords} f2 Position of finger 2.</li>
+         *     <li>{Number} dist Distance between finger 1 and 2</li>
+         *     <li>{Number} dx Distance between finger 1 and 2 (x direction)</li>
+         *     <li>{Number} dy Distance between finger 1 and 2 (y direction)</li>
          *     </ul>
          * @see JXG.Board.twoFingerGestureStart
          * @see JXG.Board.gestureChangeListener
@@ -1700,14 +1700,15 @@ JXG.extend(
                 movementAngle: movementAngle,
 
                 factor: factor,
-                dx: dx,
-                dy: dy,
 
                 fingerLineAngle: fingerLineAngle,
                 center: center,
                 p1: p1,
                 p2: p2,
+
                 dist: dist,
+                dx: dx,
+                dy: dy,
             };
         },
 

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1634,10 +1634,9 @@ JXG.extend(
 
         /**
          * Moves elements in multitouch mode.
-         * @param {Array} p1 x,y coordinates of first touch
-         * @param {Array} p2 x,y coordinates of second touch
          * @param {Object} o The touch object that is dragged: {JXG.Board#touches}.
-         * @param {Object} evt The event object that lead to this movement.
+         * @param {String} id pointerId of the event. In case of old touch event this is emulated.
+         * @param {Event} evt The event object that lead to this movement.
          */
         twoFingerMove: function (o, id, evt) {
             var drag;
@@ -1653,9 +1652,9 @@ JXG.extend(
                 drag.elementClass === Const.OBJECT_CLASS_LINE ||
                 drag.type === Const.OBJECT_TYPE_POLYGON
             ) {
-                this.twoFingerTouchObject(o.targets, drag, id);
+                this.twoFingerTouchObject(o.targets, drag, id, evt);
             } else if (drag.elementClass === Const.OBJECT_CLASS_CIRCLE) {
-                this.twoFingerTouchCircle(o.targets, drag, id);
+                this.twoFingerTouchCircle(o.targets, drag, id, evt);
             }
 
             if (evt) {
@@ -1717,6 +1716,7 @@ JXG.extend(
          * @param {Object} finger2 Actual and previous position of finger 2
          * @param {Boolean} scalable Flag if element may be scaled
          * @param {Boolean} rotatable Flag if element may be rotated
+         * @param {Event} evt The event object that lead to this movement.
          * @returns {Object} Transformation parameters <ul>
          *     <li><tt>{Array} generic</tt> Array of length 9</li>
          *     <li><tt>{Array} affine</tt> Array of length 6</li>
@@ -1728,9 +1728,8 @@ JXG.extend(
          *     </ul></li>
          *     </ul>
          */
-        getTwoFingerTransforms: function (finger1, finger2, scalable, rotatable) {
-            var gesture,
-                crd,
+            var crd,
+        getTwoFingerTransforms: function (finger1, finger2, scalable, rotatable, evt) {
                 x1, y1, x2, y2,
                 dx, dy,
                 xx1, yy1, xx2, yy2,
@@ -1833,8 +1832,9 @@ JXG.extend(
          * @param {Array} tar Array containing touch event objects: {JXG.Board#touches.targets}.
          * @param {object} drag The object that is dragged:
          * @param {Number} id pointerId of the event. In case of old touch event this is emulated.
+         * @param {Event} evt The event object that lead to this movement.
          */
-        twoFingerTouchObject: function (tar, drag, id) {
+        twoFingerTouchObject: function (tar, drag, id, evt) {
             var t, T,
                 ar, i, len,
                 snap = false;
@@ -1848,7 +1848,8 @@ JXG.extend(
                 T = this.getTwoFingerTransforms(
                     tar[0], tar[1],
                     drag.evalVisProp('scalable'),
-                    drag.evalVisProp('rotatable')
+                    drag.evalVisProp('rotatable'),
+                    evt
                 );
                 t = this.create('transform', T.twofingers, {type: 'twofingers'});
                 t.update();
@@ -1892,8 +1893,9 @@ JXG.extend(
          * @param {Array} tar Array containing touch event objects: {JXG.Board#touches.targets}.
          * @param {object} drag The object that is dragged:
          * @param {Number} id pointerId of the event. In case of old touch event this is emulated.
+         * @param {Event} evt The event object that lead to this movement.
          */
-        twoFingerTouchCircle: function (tar, drag, id) {
+        twoFingerTouchCircle: function (tar, drag, id, evt) {
             var fixEl, moveEl, np, op, fix, d, alpha, t1, t2, t3, t4;
 
             if (drag.method === 'pointCircle' || drag.method === 'pointLine') {

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1555,23 +1555,84 @@ JXG.extend(
         },
 
         /**
-         * Compute the transformation matrix to move an element according to the
+         * Compute the transformation parameters to move an element according to the
          * previous and actual positions of finger 1 and finger 2.
          * See also https://math.stackexchange.com/questions/4010538/solve-for-2d-translation-rotation-and-scale-given-two-touch-point-movements
          *
+         * Each two finger movement consists of <ul>
+         * <li>translation in directions x and y (tx, ty),</li>
+         * <li>scaling in directions x and y (sx, sy) and</li>
+         * <li>rotation with angle r (in Radians)</li>
+         * </ul>
+         *
+         * The result can be used to create transformation(s) that represent the movement.
+         * Possible combinations, using the attributes of the return value, are:
+         * <ul>
+         *     <li>
+         *         <b>generic</b>: Array
+         *         <pre>
+         *           [1, 0, 0,
+         *           tx, sx*cos(r), -sy*sin(r),
+         *           ty, sx*sos(r), sy*cos(r)]
+         *         </pre>
+         *     </li>
+         *     <li>
+         *         <b>affine</b>: Array
+         *         <pre>
+         *           [tx, sx*cos(r), -sy*sin(r),
+         *           ty, sx*sos(r), sy*cos(r)]
+         *         </pre>
+         *     </li>
+         *     <li>
+         *         <b>twofingers</b>: Array
+         *         <pre>
+         *           [tx, ty, s, r]
+         *         </pre>
+         *     </li>
+         *     <li>
+         *         <b>translation * scale * rotation</b>: Arrays
+         *         <pre>
+         *           [tx, ty]
+         *         </pre>,
+         *         <pre>
+         *           [sx, sy]
+         *         </pre> and
+         *         <pre>
+         *           [r]
+         *         </pre>
+         *         If one of these transformations does not exist, the value is null.
+         *     </li>
+         * </ul>
+         *
          * @param {Object} finger1 Actual and previous position of finger 1
-         * @param {Object} finger1 Actual and previous position of finger 1
+         * @param {Object} finger2 Actual and previous position of finger 2
          * @param {Boolean} scalable Flag if element may be scaled
          * @param {Boolean} rotatable Flag if element may be rotated
-         * @returns {Array}
+         * @param {Event} evt The event object that lead to this movement.
+         * @returns {Object} Transformation parameters <ul>
+         *     <li><tt>{Array} generic</tt> Array of length 9</li>
+         *     <li><tt>{Array} affine</tt> Array of length 6</li>
+         *     <li><tt>{Array} twofingers</tt> Array of length 4</li>
+         *     <li><tt>{Object} single</tt><ul>
+         *          <li><tt>{Array|null} translate</tt> Array of length 2</li>
+         *          <li><tt>{Array|null} scale</tt> Array of length 2</li>
+         *          <li><tt>{Array|null} rotate</tt> Array of length 1</li>
+         *     </ul></li>
+         *     </ul>
          */
-        getTwoFingerTransform(finger1, finger2, scalable, rotatable) {
-            var crd,
+        getTwoFingerTransforms: function (finger1, finger2, scalable, rotatable, evt) {
+            var gesture,
+                crd,
                 x1, y1, x2, y2,
                 dx, dy,
                 xx1, yy1, xx2, yy2,
                 dxx, dyy,
                 C, S, LL, tx, ty, lbda;
+
+            gesture = this.twoFingerGesture(evt);
+            if (Type.isEmpty(gesture)) {
+                return false;
+            }
 
             crd = new Coords(Const.COORDS_BY_SCREEN, [finger1.Xprev, finger1.Yprev], this).usrCoords;
             x1 = crd[1];
@@ -1595,20 +1656,69 @@ JXG.extend(
             LL = dx * dx + dy * dy;
             C = (dxx * dx + dyy * dy) / LL;
             S = (dyy * dx - dxx * dy) / LL;
+
+            lbda = Mat.hypot(C, S);
             if (!scalable) {
-                lbda = Mat.hypot(C, S);
                 C /= lbda;
                 S /= lbda;
+                lbda = 1;
             }
             if (!rotatable) {
                 S = 0;
             }
+
             tx = 0.5 * (xx1 + xx2 - C * (x1 + x2) + S * (y1 + y2));
             ty = 0.5 * (yy1 + yy2 - S * (x1 + x2) - C * (y1 + y2));
 
-            return [1, 0, 0,
-                tx, C, -S,
-                ty, S, C];
+            return {
+                generic: [
+                    1, 0, 0,
+                    tx, C, -S,
+                    ty, S, C
+                ],
+
+                affine: [
+                    tx, C, -S,
+                    ty, S, C
+                ],
+
+                twofingers: [
+                    tx,ty,
+                    lbda,
+                    Math.atan2(S, C)
+                ],
+
+                single: {
+                    translate: (tx !== 0 || ty !== 0)
+                        ? [tx, ty]
+                        : null,
+
+                    scale: (scalable && lbda !== 1)
+                        ? [lbda, lbda]
+                        : null,
+
+                    rotate: (rotatable && S !== 0)
+                        ? [Math.atan2(S, C)]
+                        : null
+                }
+            };
+        },
+
+        /**
+         * Compute the (generic) transformation matrix (as array) to move an element according to the
+         * previous and actual positions of finger 1 and finger 2.
+         *
+         * @see  JXG.Board#getTwoFingerTransforms
+         *
+         * @param {Object} finger1 Actual and previous position of finger 1
+         * @param {Object} finger2 Actual and previous position of finger 2
+         * @param {Boolean} scalable Flag if element may be scaled
+         * @param {Boolean} rotatable Flag if element may be rotated
+         * @returns {Array}
+         * @deprecated
+         */
+        getTwoFingerTransform: function (finger1, finger2, scalable, rotatable) {
+            return this.getTwoFingerTransforms(finger1, finger2, scalable, rotatable).generic;
         },
 
         /**

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1566,8 +1566,9 @@ JXG.extend(
          * Gives information about a two finger gesture.
          *
          * @param {Event} evt
-         * @param {Boolean} [allowPan=true]
          * @param {Number} [pinchDirSensitivity=5] Sensitivity (in degrees) for recognizing horizontal or vertical pinch gestures.
+         * @param {Boolean} [allowPan=true]
+         * @param {Boolean} [panPinchExclusive=true]
          * @param {Boolean} [filterSmallMovements=false]
          * @returns {Object|null} <ul>
          *     <li>{Boolean} isPinch</li>
@@ -1591,7 +1592,7 @@ JXG.extend(
          * @see JXG.Board.gestureChangeListener
          * @see JXG.Board.twoFingerTouchObject
          */
-        twoFingerGesture: function (evt, allowPan, pinchDirSensitivity, filterSmallMovements) {
+        twoFingerGesture: function (evt, pinchDirSensitivity, allowPan, panPinchExclusive, filterSmallMovements) {
             var mi = 10,
                 dir1, dir2,
                 movementAngle,
@@ -1614,6 +1615,9 @@ JXG.extend(
             }
             if (!Type.exists(allowPan)) {
                 allowPan = true;
+            }
+            if (!Type.exists(panPinchExclusive)) {
+                panPinchExclusive = true;
             }
             if (!Type.exists(pinchDirSensitivity)) {
                 pinchDirSensitivity = 5;
@@ -1675,7 +1679,7 @@ JXG.extend(
                 }
             }
 
-            isPan = allowPan && !isPinch;
+            isPan = allowPan && (panPinchExclusive ? !isPinch : true);
 
             this.prevCoords = [p1, p2];
             this.prevScale = evt.scale;
@@ -1802,7 +1806,7 @@ JXG.extend(
          * @param {Object} finger2 Actual and previous position of finger 2
          * @param {Boolean} scalable Flag if element may be scaled
          * @param {Boolean} rotatable Flag if element may be rotated
-         * @param {Event} evt The event object that lead to this movement.
+         * @param {Event} [evt] The event object that lead to this movement.
          * @returns {Object} Transformation parameters <ul>
          *     <li><tt>{Array} generic</tt> Array of length 9</li>
          *     <li><tt>{Array} affine</tt> Array of length 6</li>
@@ -2718,8 +2722,9 @@ JXG.extend(
 
             gesture = this.twoFingerGesture(
                 evt,
-                this.attr.pan.enabled && this.attr.pan.needtwofingers,
                 this.attr.zoom.pinchsensitivity,
+                this.attr.pan.enabled && this.attr.pan.needtwofingers,
+                true,
                 true
             );
             if (!Type.exists(gesture)) {

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1545,20 +1545,8 @@ JXG.extend(
             if (Type.exists(dist)) { // Android pinch to zoom
                 this.prevDist = dist;
             }
-            this.saveTwoFingerGesture(gesture);
-        },
-
-        /**
-         * Saves value in this.isPreviousGesture if it exists.
-         * This is necessary for {@link JXG.Board.twoFingerGesture}.
-         *
-         * @param {String|null} value
-         * @see JXG.Board.twoFingerGesture
-         * @see JXG.Board.saveTwoFingerGesture
-         */
-        saveTwoFingerGesture: function (value) {
-            if (Type.exists(value)) {
-                this.isPreviousGesture = value;
+            if (Type.exists(gesture)) {
+                this.isPreviousGesture = gesture;
             }
         },
 
@@ -2671,7 +2659,7 @@ JXG.extend(
 
             if (this.attr.pan.enabled && this.attr.pan.needtwofingers && !gesture.isPinch) {
                 // Pan detected
-                this.saveTwoFingerGesture('pan');
+                this.isPreviousGesture = 'pan';
                 this.moveOrigin(c.scrCoords[1], c.scrCoords[2], true);
 
             } else if (this.attr.zoom.enabled && Math.abs(gesture.factor - 1.0) < 0.5) {

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1617,24 +1617,10 @@ JXG.extend(
 
             p1 = this.getMousePosition(evt, 0);
             p2 = this.getMousePosition(evt, 1);
-            center = new Coords(
-                Const.COORDS_BY_SCREEN,
-                [
-                    0.5 * (p1[0] + p2[0]),
-                    0.5 * (p1[1] + p2[1])
-                ],
-                this
-            );
-            p1 = new Coords(Const.COORDS_BY_SCREEN, p1, this);
-            p2 = new Coords(Const.COORDS_BY_SCREEN, p2, this);
 
-            dist = Geometry.distance(
-                [evt.touches[0].clientX, evt.touches[0].clientY],
-                [evt.touches[1].clientX, evt.touches[1].clientY],
-                2
-            );
-            dx = Math.abs(evt.touches[0].clientX - evt.touches[1].clientX);
-            dy = Math.abs(evt.touches[0].clientY - evt.touches[1].clientY);
+            dist = Geometry.distance(p1, p2, 2);
+            dx = Math.abs(p1[0] - p2[0]);
+            dy = Math.abs(p1[1] - p2[1]);
             fingerLineAngle = Math.abs(Math.atan2(dy, dx));
 
             // Android pinch to zoom
@@ -1645,12 +1631,12 @@ JXG.extend(
             }
 
             dir1 = [
-                evt.touches[0].clientX - this.prevCoords[0][0],
-                evt.touches[0].clientY - this.prevCoords[0][1]
+                p1[0] - this.prevCoords[0][0],
+                p1[1] - this.prevCoords[0][1]
             ];
             dir2 = [
-                evt.touches[1].clientX - this.prevCoords[1][0],
-                evt.touches[1].clientY - this.prevCoords[1][1]
+                p2[0] - this.prevCoords[1][0],
+                p2[1] - this.prevCoords[1][1]
             ];
 
             if (
@@ -1685,15 +1671,23 @@ JXG.extend(
 
             isPan = allowPan && !isPinch;
 
-            this.prevCoords = [
-                [evt.touches[0].clientX, evt.touches[0].clientY],
-                [evt.touches[1].clientX, evt.touches[1].clientY]
-            ];
+            this.prevCoords = [p1, p2];
             this.prevScale = evt.scale;
             if (isPan) {
                 // if pan is detected once, stay to pan
                 this.isPreviousGesture = 'pan';
             }
+
+            center = new Coords(
+                Const.COORDS_BY_SCREEN,
+                [
+                    0.5 * (p1[0] + p2[0]),
+                    0.5 * (p1[1] + p2[1])
+                ],
+                this
+            );
+            p1 = new Coords(Const.COORDS_BY_SCREEN, p1, this);
+            p2 = new Coords(Const.COORDS_BY_SCREEN, p2, this);
 
             return {
                 isPinch: isPinch,

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1524,7 +1524,8 @@ JXG.extend(
         },
 
         /**
-         * Saves value in this.prevCoords, this.prevScale, this.prevDist and this.isPreviousGesture if the new values are not null.
+         * Saves values in this.prevCoords, this.prevScale, this.prevDist and this.isPreviousGesture
+         * if the new values are not null.
          * This is necessary for {@link JXG.Board.twoFingerPinch}.
          *
          * @param {Array|null} coords
@@ -1532,6 +1533,7 @@ JXG.extend(
          * @param {Number|null} dist
          * @param {String|null} gesture
          * @see JXG.Board.twoFingerPinch
+         * @see JXG.Board.saveTwoFingerGesture
          */
         saveTwoFingerPinch: function (coords, scale, dist, gesture) {
             if (Type.exists(coords)) {
@@ -1546,12 +1548,35 @@ JXG.extend(
             this.saveTwoFingerGesture(gesture);
         },
 
-        saveTwoFingerGesture: function (gesture) {
-            if (Type.exists(gesture)) {
-                this.isPreviousGesture = gesture;
+        /**
+         * Saves value in this.isPreviousGesture if it exists.
+         * This is necessary for {@link JXG.Board.twoFingerPinch}.
+         *
+         * @param {String|null} value
+         * @see JXG.Board.twoFingerPinch
+         * @see JXG.Board.saveTwoFingerGesture
+         */
+        saveTwoFingerGesture: function (value) {
+            if (Type.exists(value)) {
+                this.isPreviousGesture = value;
             }
         },
 
+        /**
+         * Gives information about a two finger gesture.
+         *
+         * @param {Event} evt
+         * @returns {Object} <ul>
+         *     <li>{Boolean} isPinch</li>
+         *     <li>{Number} factor</li>
+         *     <li>{Array} dir1</li>
+         *     <li>{Array} dir2</li>
+         *     <li>{Number} dist</li>
+         *     <li>{Number} angle</li>
+         *     </ul>
+         * @see JXG.Board.gestureChangeListener
+         * @see JXG.Board.twoFingerTouchObject
+         */
         twoFingerPinch: function (evt) {
             var mi = 10,
                 dir1 = [],
@@ -1728,13 +1753,17 @@ JXG.extend(
          *     </ul></li>
          *     </ul>
          */
-            var crd,
         getTwoFingerTransforms: function (finger1, finger2, scalable, rotatable, evt) {
+            var pinch,
+                crd,
                 x1, y1, x2, y2,
                 dx, dy,
                 xx1, yy1, xx2, yy2,
                 dxx, dyy,
                 C, S, LL, tx, ty, lbda;
+
+            pinch = this.twoFingerPinch(evt);
+           // console.log(pinch);
 
             crd = new Coords(Const.COORDS_BY_SCREEN, [finger1.Xprev, finger1.Yprev], this).usrCoords;
             x1 = crd[1];

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -1552,6 +1552,85 @@ JXG.extend(
             }
         },
 
+        twoFingerPinch: function (evt) {
+            var mi = 10,
+                dir1 = [],
+                dir2 = [],
+                angle,
+                factor,
+                dist,
+                isPinch = false;
+
+            if (!Type.exists(this.prevCoords) ||
+                !Type.exists(evt.touches) ||
+                evt.touches.length < 2) {
+                return {};
+            }
+
+            dist = Geometry.distance(
+                [evt.touches[0].clientX, evt.touches[0].clientY],
+                [evt.touches[1].clientX, evt.touches[1].clientY],
+                2
+            );
+
+            // Android pinch to zoom
+            // evt.scale was available in iOS touch events (pre iOS 13)
+            // evt.scale is undefined in Android
+            if (evt.scale === undefined) {
+                evt.scale = dist / this.prevDist;
+            }
+
+            // Compute the angle of the two finger directions
+            dir1 = [
+                evt.touches[0].clientX - this.prevCoords[0][0],
+                evt.touches[0].clientY - this.prevCoords[0][1]
+            ];
+            dir2 = [
+                evt.touches[1].clientX - this.prevCoords[1][0],
+                evt.touches[1].clientY - this.prevCoords[1][1]
+            ];
+
+            if (
+                dir1[0] * dir1[0] + dir1[1] * dir1[1] < mi * mi &&
+                dir2[0] * dir2[0] + dir2[1] * dir2[1] < mi * mi
+            ) {
+                return {}; // too small movement
+            }
+
+            angle = Geometry.rad(dir1, [0, 0], dir2);
+            if (
+                this.isPreviousGesture !== 'pan' &&
+                Math.abs(angle) > Math.PI * 0.2 &&
+                Math.abs(angle) < Math.PI * 1.8
+            ) {
+                isPinch = true;
+            }
+
+            if (this.isPreviousGesture !== 'pan' && !isPinch) {
+                if (Math.abs(evt.scale) < 0.77 || Math.abs(evt.scale) > 1.3) {
+                    isPinch = true;
+                }
+            }
+
+            factor = evt.scale / this.prevScale;
+
+            this.saveTwoFingerPinch(
+                [ // coords
+                    [evt.touches[0].clientX, evt.touches[0].clientY],
+                    [evt.touches[1].clientX, evt.touches[1].clientY]
+                ],
+                evt.scale // scale
+            );
+
+            return {
+                isPinch: isPinch,
+                factor: factor,
+                dir1: dir1,
+                dir2: dir2,
+                dist: dist,
+                angle: angle
+            };
+        },
 
         /**
          * Moves elements in multitouch mode.
@@ -2538,15 +2617,11 @@ JXG.extend(
          */
         gestureChangeListener: function (evt) {
             var c,
-                dir1 = [],
-                dir2 = [],
-                angle,
-                mi = 10,
-                isPinch = false,
+                pinch,
                 // Save zoomFactors
                 zx = this.attr.zoom.factorx,
                 zy = this.attr.zoom.factory,
-                factor, dist, theta, bound,
+                theta, bound,
                 zoomCenter,
                 doZoom = false,
                 dx, dy, cx, cy;
@@ -2556,69 +2631,19 @@ JXG.extend(
             }
             evt.preventDefault();
 
-            dist = Geometry.distance(
-                [evt.touches[0].clientX, evt.touches[0].clientY],
-                [evt.touches[1].clientX, evt.touches[1].clientY],
-                2
-            );
-
-            // Android pinch to zoom
-            // evt.scale was available in iOS touch events (pre iOS 13)
-            // evt.scale is undefined in Android
-            if (evt.scale === undefined) {
-                evt.scale = dist / this.prevDist;
-            }
-
-            if (!Type.exists(this.prevCoords)) {
+            pinch = this.twoFingerPinch(evt);
+            if (Type.isEmpty(pinch)) {
                 return false;
             }
-            // Compute the angle of the two finger directions
-            dir1 = [
-                evt.touches[0].clientX - this.prevCoords[0][0],
-                evt.touches[0].clientY - this.prevCoords[0][1]
-            ];
-            dir2 = [
-                evt.touches[1].clientX - this.prevCoords[1][0],
-                evt.touches[1].clientY - this.prevCoords[1][1]
-            ];
-
-            if (
-                dir1[0] * dir1[0] + dir1[1] * dir1[1] < mi * mi &&
-                dir2[0] * dir2[0] + dir2[1] * dir2[1] < mi * mi
-            ) {
-                return false;
-            }
-
-            angle = Geometry.rad(dir1, [0, 0], dir2);
-            if (
-                this.isPreviousGesture !== 'pan' &&
-                Math.abs(angle) > Math.PI * 0.2 &&
-                Math.abs(angle) < Math.PI * 1.8
-            ) {
-                isPinch = true;
-            }
-
-            if (this.isPreviousGesture !== 'pan' && !isPinch) {
-                if (Math.abs(evt.scale) < 0.77 || Math.abs(evt.scale) > 1.3) {
-                    isPinch = true;
-                }
-            }
-
-            factor = evt.scale / this.prevScale;
-            this.prevScale = evt.scale;
-            this.prevCoords = [
-                [evt.touches[0].clientX, evt.touches[0].clientY],
-                [evt.touches[1].clientX, evt.touches[1].clientY]
-            ];
 
             c = new Coords(Const.COORDS_BY_SCREEN, this.getMousePosition(evt, 0), this);
 
-            if (this.attr.pan.enabled && this.attr.pan.needtwofingers && !isPinch) {
+            if (this.attr.pan.enabled && this.attr.pan.needtwofingers && !pinch.isPinch) {
                 // Pan detected
                 this.saveTwoFingerGesture('pan');
                 this.moveOrigin(c.scrCoords[1], c.scrCoords[2], true);
 
-            } else if (this.attr.zoom.enabled && Math.abs(factor - 1.0) < 0.5) {
+            } else if (this.attr.zoom.enabled && Math.abs(pinch.factor - 1.0) < 0.5) {
                 doZoom = false;
                 zoomCenter = this.attr.zoom.center;
                 // Pinch detected
@@ -2632,7 +2657,7 @@ JXG.extend(
                 if (!this.keepaspectratio &&
                     this.attr.zoom.pinchhorizontal &&
                     theta < bound) {
-                    this.attr.zoom.factorx = factor;
+                    this.attr.zoom.factorx = pinch.factor;
                     this.attr.zoom.factory = 1.0;
                     cx = 0;
                     cy = 0;
@@ -2642,13 +2667,13 @@ JXG.extend(
                     Math.abs(theta - Math.PI * 0.5) < bound
                 ) {
                     this.attr.zoom.factorx = 1.0;
-                    this.attr.zoom.factory = factor;
+                    this.attr.zoom.factory = pinch.factor;
                     cx = 0;
                     cy = 0;
                     doZoom = true;
                 } else if (this.attr.zoom.pinch) {
-                    this.attr.zoom.factorx = factor;
-                    this.attr.zoom.factory = factor;
+                    this.attr.zoom.factorx = pinch.factor;
+                    this.attr.zoom.factory = pinch.factor;
                     cx = c.usrCoords[1];
                     cy = c.usrCoords[2];
                     doZoom = true;

--- a/src/base/transformation.js
+++ b/src/base/transformation.js
@@ -1064,6 +1064,15 @@ JXG.extend(
          * @returns {JXG.Transform} the transformation object.
          */
         melt: function (t) {
+            const closedTypes = [
+                'translate',
+                'scale',
+                'affine',
+                'affinematrix',
+                'generic',
+                'matrix'
+                // 'rotate' is handled separately
+            ];
             var res = [];
 
             this.update();
@@ -1074,6 +1083,26 @@ JXG.extend(
             this.update = function () {
                 this.matrix = res;
             };
+            delete this.evalParam;
+
+            if (
+                this.transformationType === t.transformationType &&
+                closedTypes.includes(this.transformationType)
+            ) {
+                // keep type
+
+            } else if (
+                !this.is3D && !t.is3D &&
+                this.transformationType === 'rotate' && t.transformationType === 'rotate' &&
+                // rotation around 0,0
+                Math.abs(this.matrix[1][0]) < Mat.eps && Math.abs(this.matrix[2][0]) < Mat.eps &&
+                Math.abs(t.matrix[1][0]) < Mat.eps && Math.abs(t.matrix[2][0]) < Mat.eps
+            ) {
+                // keep type 'rotate'
+
+            } else {
+                this.transformationType = 'melted';
+            }
 
             return this;
         },

--- a/src/base/transformation.js
+++ b/src/base/transformation.js
@@ -993,7 +993,8 @@ JXG.extend(
          * @see JXG.Transformation#bindTo
          */
         meltTo: function (el) {
-            var i, elt, t;
+            var i, elt, t,
+                meltSameType = el.evalVisProp('meltOnlySameTransformationType');
 
             if (Type.isArray(el)) {
                 for (i = 0; i < el.length; i++) {
@@ -1006,7 +1007,11 @@ JXG.extend(
                     elt[elt.length - 1].isNumericMatrix &&
                     this.isNumericMatrix
                 ) {
-                    elt[elt.length - 1].melt(this);
+                    if (meltSameType && elt[elt.length - 1].transformationType !== this.transformationType) {
+                        this.bindTo(el);
+                    } else {
+                        elt[elt.length - 1].melt(this);
+                    }
                 } else {
                     // Use a clone of the transformation.
                     // Otherwise, if the transformation is meltTo twice

--- a/src/base/transformation.js
+++ b/src/base/transformation.js
@@ -1154,6 +1154,193 @@ JXG.extend(
             return this;
         },
 
+        getParams: function () {
+            let i, j, len,
+                angle,
+                co, si, tx, ty, det, x, y,
+                type = this.transformationType,
+                res = [];
+
+            if (Type.exists(this.evalParam) && Type.exists(this.evalParam.n)) {
+                len = this.evalParam.n;
+                for (i = 0; i < len; i++) {
+                    res[i] = this.evalParam(i);
+                }
+
+            } else if (!this.is3D) { ////////////////////////// 2D
+                if (type === 'translate') {
+                    res = [this.matrix[1][0], this.matrix[2][0]];
+
+                } else if (type === 'reflect') {
+                    // Not uniquely recoverable in general.
+
+                } else if (type === 'rotate') {
+                    co = this.matrix[1][1];
+                    si = this.matrix[2][1];
+                    tx = this.matrix[1][0];
+                    ty = this.matrix[2][0];
+                    angle = Math.atan2(si, co);
+                    det = (1 - co) * (1 - co) + si * si;
+
+                    if (Math.abs(det) < Mat.eps) {
+                        res = [angle];
+                    } else {
+                        x = ((1 - co) * tx - si * ty) / det;
+                        y = (si * tx + (1 - co) * ty) / det;
+
+                        if (Math.abs(x) < Mat.eps) {
+                            x = 0;
+                        }
+                        if (Math.abs(y) < Mat.eps) {
+                            y = 0;
+                        }
+
+                        res = [angle, x, y];
+                    }
+
+                } else if (type === 'shear') {
+                    res = [this.matrix[1][2], this.matrix[2][1]];
+
+                } else if (type === 'affine') {
+                    if (
+                        this.matrix[1][0] === 0 && this.matrix[2][0] === 0
+                    ) {
+                        res = [
+                            this.matrix[1][1], this.matrix[1][2],
+                            this.matrix[2][1], this.matrix[2][2]
+                        ];
+                    } else {
+                        res = [
+                            this.matrix[1][0], this.matrix[1][1], this.matrix[1][2],
+                            this.matrix[2][0], this.matrix[2][1], this.matrix[2][2]
+                        ];
+                    }
+
+                } else if (type === 'affinematrix') {
+                    if (
+                        this.matrix[1][0] === 0 &&
+                        this.matrix[2][0] === 0
+                    ) {
+                        res = [
+                            [this.matrix[1][1], this.matrix[1][2]],
+                            [this.matrix[2][1], this.matrix[2][2]]
+                        ];
+                    } else {
+                        res = [
+                            [this.matrix[1][0], this.matrix[1][1], this.matrix[1][2]],
+                            [this.matrix[2][0], this.matrix[2][1], this.matrix[2][2]]
+                        ];
+                    }
+
+                } else if (type === 'twofingers') {
+                    res = [
+                        this.matrix[1][0], // tx
+                        this.matrix[2][0], // ty
+                        Mat.hypot(         // s
+                            this.matrix[1][1],
+                            this.matrix[2][1]
+                        ),
+                        Math.atan2(        // angle
+                            this.matrix[2][1],
+                            this.matrix[1][1]
+                        )
+                    ];
+
+                } else if (type === 'generic') {
+                    for (i = 0; i < 3; i++) {
+                        for (j = 0; j < 3; j++) {
+                            res.push(this.matrix[i][j]);
+                        }
+                    }
+
+                } else if (type === 'matrix') {
+                    res = this.matrix.slice();
+                }
+
+            } else { ////////////////////////////////////////// 3D
+                if (type === 'translate') {
+                    res = [this.matrix[1][0], this.matrix[2][0], this.matrix[3][0]];
+
+                } else if (type === 'scale') {
+                    res = [this.matrix[1][1], this.matrix[2][2], this.matrix[3][3]];
+
+                } else if (type === 'rotateX') {
+                    angle = Math.atan2(
+                        this.matrix[3][2],
+                        this.matrix[2][2]
+                    );
+                    res = [angle];
+
+                } else if (type === 'rotateY') {
+                    angle = Math.atan2(
+                        this.matrix[1][3],
+                        this.matrix[1][1]
+                    );
+                    res = [angle];
+
+                } else if (type === 'rotateZ') {
+                    angle = Math.atan2(
+                        this.matrix[2][1],
+                        this.matrix[1][1]
+                    );
+                    res = [angle];
+
+                } else if (type === 'rotate') {
+                    // Not uniquely recoverable in general.
+
+                } else if (type === 'affine') {
+                    if (
+                        this.matrix[1][0] === 0 &&
+                        this.matrix[2][0] === 0 &&
+                        this.matrix[3][0] === 0
+                    ) {
+                        res = [
+                            this.matrix[1][1], this.matrix[1][2], this.matrix[1][3],
+                            this.matrix[2][1], this.matrix[2][2], this.matrix[2][3],
+                            this.matrix[3][1], this.matrix[3][2], this.matrix[3][3]
+                        ];
+                    } else {
+                        res = [
+                            this.matrix[1][0], this.matrix[1][1], this.matrix[1][2], this.matrix[1][3],
+                            this.matrix[2][0], this.matrix[2][1], this.matrix[2][2], this.matrix[2][3],
+                            this.matrix[3][0], this.matrix[3][1], this.matrix[3][2], this.matrix[3][3]
+                        ];
+                    }
+
+                } else if (type === 'affinematrix') {
+                    if (
+                        this.matrix[1][0] === 0 &&
+                        this.matrix[2][0] === 0 &&
+                        this.matrix[3][0] === 0
+                    ) {
+                        res = [
+                            [this.matrix[1][1], this.matrix[1][2], this.matrix[1][3]],
+                            [this.matrix[2][1], this.matrix[2][2], this.matrix[2][3]],
+                            [this.matrix[3][1], this.matrix[3][2], this.matrix[3][3]]
+                        ];
+                    } else {
+                        res = [
+                            [this.matrix[1][0], this.matrix[1][1], this.matrix[1][2], this.matrix[1][3]],
+                            [this.matrix[2][0], this.matrix[2][1], this.matrix[2][2], this.matrix[2][3]],
+                            [this.matrix[3][0], this.matrix[3][1], this.matrix[3][2], this.matrix[3][3]]
+                        ];
+                    }
+
+                } else if (type === 'generic') {
+                    for (i = 0; i < 4; i++) {
+                        for (j = 0; j < 4; j++) {
+                            res.push(this.matrix[i][j]);
+                        }
+                    }
+
+                } else if (type === 'matrix') {
+                    res = this.matrix.slice();
+                }
+            }
+
+            return res;
+        },
+
         // Documented in element.js
         // Not yet, since transformations are not listed in board.objects.
         getParents: function () {

--- a/src/base/transformation.js
+++ b/src/base/transformation.js
@@ -1176,6 +1176,9 @@ JXG.extend(
                 if (type === 'translate') {
                     res = [this.matrix[1][0], this.matrix[2][0]];
 
+                } else if (type === 'scale') {
+                    res = [this.matrix[1][1], this.matrix[2][2]];
+
                 } else if (type === 'reflect') {
                     // Not uniquely recoverable in general.
 

--- a/src/base/transformation.js
+++ b/src/base/transformation.js
@@ -93,18 +93,30 @@ import Type from "../utils/type.js";
  * ( 0  b  1)   ( y )
  * </pre>
  *
- * <p>Generic affine transformation (4 parameters):
+ * <p>Affine transformation (4 or 6 parameters):
  * <pre>
  * ( 1  0  0 )   ( z )
  * ( 0  a  b ) * ( x )
  * ( 0  c  d )   ( y )
  * </pre>
+ * or (including translation)
+ * <pre>
+ * ( 1  0  0 )   ( z )
+ * ( a  b  c ) * ( x )
+ * ( d  e  f )   ( y )
+ * </pre>
  *
- * <p>Affine 2x2 matrix:
+ * <p>Affine 2x2 or 2x3 matrix:
  * <pre>
  * ( 1  0  0 )   ( z )
  * ( 0  M    ) * ( x )
  * ( 0       )   ( y )
+ * </pre>
+ * or (including translation)
+ * <pre>
+ * ( 1  0  0 )   ( z )
+ * ( M       ) * ( x )
+ * (         )   ( y )
  * </pre>
  *
  * <p>Generic transformation (9 parameters):
@@ -238,11 +250,25 @@ JXG.extend(
          * ( 0  c  d )   ( y )
          * </pre>
          *
+         * <p>Generic affine transformation (6 parameters, including translation):
+         * <pre>
+         * ( 1  0  0 )   ( z )
+         * ( a  b  c ) * ( x )
+         * ( d  e  f )   ( y )
+         * </pre>
+         *
          * <p>Affine 2x2 matrix:
          * <pre>
          * ( 1  0  0 )   ( z )
          * ( 0  M    ) * ( x )
          * ( 0       )   ( y )
+         * </pre>
+         *
+         * <p>Affine 2x3 matrix (including translation):
+         * <pre>
+         * ( 1  0  0 )   ( z )
+         * (    M    ) * ( x )
+         * (         )   ( y )
          * </pre>
          *
          * <p>Generic transformation (9 parameters):
@@ -419,32 +445,58 @@ JXG.extend(
                     this.matrix[2][1] = this.evalParam(1);
                 };
             } else if (type === 'affine') {
-                if (params.length !== 4) {
-                    throw new Error("JSXGraph: affine transformation needs 4 parameters.");
+                if (params.length !== 4 && params.length !== 6) {
+                    throw new Error("JSXGraph: affine transformation needs 4 or 6 parameters.");
                 }
 
-                this.evalParam = Type.createEvalFunction(board, params, 9);
-
-                this.update = function () {
-                    this.matrix[1][1] = this.evalParam(0);
-                    this.matrix[1][2] = this.evalParam(1);
-                    this.matrix[2][1] = this.evalParam(2);
-                    this.matrix[2][2] = this.evalParam(3);
-                };
+                if (params.length === 4) {
+                    this.evalParam = Type.createEvalFunction(board, params, 4);
+                    this.update = function () {
+                        this.matrix[1][1] = this.evalParam(0);
+                        this.matrix[1][2] = this.evalParam(1);
+                        this.matrix[2][1] = this.evalParam(2);
+                        this.matrix[2][2] = this.evalParam(3);
+                    };
+                } else if (params.length === 6) {
+                    this.evalParam = Type.createEvalFunction(board, params, 6);
+                    this.update = function () {
+                        this.matrix[1][0] = this.evalParam(0);
+                        this.matrix[1][1] = this.evalParam(1);
+                        this.matrix[1][2] = this.evalParam(2);
+                        this.matrix[2][0] = this.evalParam(3);
+                        this.matrix[2][1] = this.evalParam(4);
+                        this.matrix[2][2] = this.evalParam(5);
+                    };
+                } else {
+                    throw new Error("JSXGraph: affine transformation needs 4 or 6 parameters.");
+                }
             } else if (type === 'affinematrix') {
                 if (params.length !== 1) {
-                    throw new Error("JSXGraph: transformation of type 'matrix' needs 1 parameter.");
+                    throw new Error("JSXGraph: transformation of type 'affinematrix' needs 1 parameter.");
                 }
 
                 this.evalParam = params[0].slice();
-                this.update = function () {
-                    var i, j;
-                    for (i = 0; i < 2; i++) {
-                        for (j = 0; j < 2; j++) {
-                            this.matrix[i + 1][j + 1] = Type.evaluate(this.evalParam[i][j]);
+                if (this.evalParam.length === 2 && this.evalParam[0].length === 2) { // 2x2 matrix
+                    this.update = function () {
+                        var i, j;
+                        for (i = 0; i < 2; i++) {
+                            for (j = 0; j < 2; j++) {
+                                this.matrix[i + 1][j + 1] = Type.evaluate(this.evalParam[i][j]);
+                            }
                         }
-                    }
-                };
+                    };
+                } else if (this.evalParam.length === 2 && this.evalParam[0].length === 3) { // 2x3 matrix
+                    this.update = function () {
+                        var i, j;
+                        for (i = 0; i < 2; i++) {
+                            for (j = 0; j < 3; j++) {
+                                this.matrix[i + 1][j] = Type.evaluate(this.evalParam[i][j]);
+                            }
+                        }
+                    };
+                } else {
+                    throw new Error("JSXGraph: transformation of type 'affinematrix' needs a 2x2 or a 2x3 matrix as parameter.");
+                }
             } else if (type === 'generic') {
                 if (params.length !== 9) {
                     throw new Error("JSXGraph: generic transformation needs 9 parameters.");
@@ -572,12 +624,28 @@ JXG.extend(
          * ( 0  g  h  i )   ( z )
          * </pre>
          *
+         * <p>Generic affine transformation (12 parameters, including translation):
+         * <pre>
+         * ( 1  0  0  0 )   ( w )
+         * ( a  b  c  d ) * ( x )
+         * ( e  f  g  h )   ( y )
+         * ( i  j  k  l )   ( z )
+         * </pre>
+         *
          * <p>Affine 3x3 matrix:
          * <pre>
          * ( 1  0  0  0 )   ( w )
          * ( 0          ) * ( x )
          * ( 0     M    )   ( y )
          * ( 0          )   ( z )
+         * </pre>
+         *
+         * <p>Affine 3x4 matrix (including translation):
+         * <pre>
+         * ( 1  0  0  0 )   ( w )
+         * (            ) * ( x )
+         * (     M      )   ( y )
+         * (            )   ( z )
          * </pre>
          *
          * <p>Generic transformation (16 parameters):
@@ -727,36 +795,69 @@ JXG.extend(
                     this.matrix = Mat.matMatMult(m2, this.matrix);
                 };
             } else if (type === 'affine') {
-                if (params.length !== 9) {
-                    throw new Error("JSXGraph: 3D transformation of type 'affine' needs 9 parameters.");
+                if (params.length !== 9 && params.length !== 12) {
+                    throw new Error("JSXGraph: 3D transformation of type 'affine' needs 9 or 12 parameters.");
                 }
 
-                this.evalParam = Type.createEvalFunction(board, params, 9);
-                this.update = function () {
-                    this.matrix[1][1] = this.evalParam(0);
-                    this.matrix[1][2] = this.evalParam(1);
-                    this.matrix[1][3] = this.evalParam(2);
-                    this.matrix[2][1] = this.evalParam(3);
-                    this.matrix[2][2] = this.evalParam(4);
-                    this.matrix[2][3] = this.evalParam(5);
-                    this.matrix[3][1] = this.evalParam(6);
-                    this.matrix[3][2] = this.evalParam(7);
-                    this.matrix[3][3] = this.evalParam(8);
-                };
+                if (params.length === 9) {
+                    this.evalParam = Type.createEvalFunction(board, params, 9);
+                    this.update = function () {
+                        this.matrix[1][1] = this.evalParam(0);
+                        this.matrix[1][2] = this.evalParam(1);
+                        this.matrix[1][3] = this.evalParam(2);
+                        this.matrix[2][1] = this.evalParam(3);
+                        this.matrix[2][2] = this.evalParam(4);
+                        this.matrix[2][3] = this.evalParam(5);
+                        this.matrix[3][1] = this.evalParam(6);
+                        this.matrix[3][2] = this.evalParam(7);
+                        this.matrix[3][3] = this.evalParam(8);
+                    };
+                } else if (params.length === 12) {
+                    this.evalParam = Type.createEvalFunction(board, params, 12);
+                    this.update = function () {
+                        this.matrix[1][0] = this.evalParam(0);
+                        this.matrix[1][1] = this.evalParam(1);
+                        this.matrix[1][2] = this.evalParam(2);
+                        this.matrix[1][3] = this.evalParam(3);
+                        this.matrix[2][0] = this.evalParam(4);
+                        this.matrix[2][1] = this.evalParam(5);
+                        this.matrix[2][2] = this.evalParam(6);
+                        this.matrix[2][3] = this.evalParam(7);
+                        this.matrix[3][0] = this.evalParam(8);
+                        this.matrix[3][1] = this.evalParam(9);
+                        this.matrix[3][2] = this.evalParam(10);
+                        this.matrix[3][3] = this.evalParam(11);
+                    };
+                } else {
+                    throw new Error("JSXGraph: 3D transformation of type 'affine' needs 9 or 12 parameters.");
+                }
             } else if (type === 'affinematrix') {
                 if (params.length !== 1) {
                     throw new Error("JSXGraph: 3D transformation of type 'affinematrix' needs 1 parameter.");
                 }
 
                 this.evalParam = params[0].slice();
-                this.update = function () {
-                    var i, j;
-                    for (i = 0; i < 3; i++) {
-                        for (j = 0; j < 3; j++) {
-                            this.matrix[i + 1][j + 1] = Type.evaluate(this.evalParam[i][j]);
+                if (this.evalParam.length === 3 && this.evalParam[0].length === 3) { // 3x3 matrix
+                    this.update = function () {
+                        var i, j;
+                        for (i = 0; i < 3; i++) {
+                            for (j = 0; j < 3; j++) {
+                                this.matrix[i + 1][j + 1] = Type.evaluate(this.evalParam[i][j]);
+                            }
                         }
-                    }
-                };
+                    };
+                } else if (this.evalParam.length === 3 && this.evalParam[0].length === 4) { // 3x4 matrix
+                    this.update = function () {
+                        var i, j;
+                        for (i = 0; i < 3; i++) {
+                            for (j = 0; j < 4; j++) {
+                                this.matrix[i + 1][j] = Type.evaluate(this.evalParam[i][j]);
+                            }
+                        }
+                    };
+                } else {
+                    throw new Error("JSXGraph: 3D transformation of type 'affinematrix' needs a 3x3 or a 3x4 matrix as parameter.");
+                }
             } else if (type === 'generic') {
                 if (params.length !== 16) {
                     throw new Error("JSXGraph: 3D transformation of type 'generic' needs 16 parameters.");
@@ -1022,6 +1123,8 @@ JXG.extend(
  * <li> 'reflect'
  * <li> 'rotate'
  * <li> 'shear'
+ * <li> 'affine'
+ * <li> 'affinematrix'
  * <li> 'generic'
  * <li> 'matrix'
  * </ul>
@@ -1068,7 +1171,7 @@ JXG.extend(
  *      <li> <b>p_x, p_y, q_x, q_y</b> four numbers or functions  determining a line through points (p_x, p_y) and (q_x, q_y).
  *    </ul>
  * </dd>
- * <dt><b><tt>type:"affine"</tt></b></dt><dd><b>a, b, c, d</b> (numbers or functions>.
+ * <dt><b><tt>type:"affine" (4 parameters)</tt></b></dt><dd><b>a, b, c, d</b> (numbers or functions).
  * The transformation matrix has the form
  * <pre>
  * ( 1  0  0 )   ( z )
@@ -1076,12 +1179,26 @@ JXG.extend(
  * ( 0  c  d )   ( y )
  * </pre>
  * </dd>
- * <dt><b><tt>type:"affinematrix"</tt></b></dt><dd><b>M</b> 2x2 matrix containing numbers or functions.
+ * <dt><b><tt>type:"affine" (6 parameters)</tt></b></dt><dd><b>a, b, c, d, e, f</b> (numbers or functions).
+ * The transformation matrix has the form
+ * <pre>
+ * ( 1  0  0 )   ( z )
+ * ( a  b  c ) * ( x )
+ * ( d  e  f )   ( y )
+ * </pre>
+ * </dd>
+ * <dt><b><tt>type:"affinematrix"</tt></b></dt><dd><b>M</b> 2x2 or 2x3 matrix containing numbers or functions.
  * The full transformation matrix has the form
  * <pre>
  * ( 1  0  0 )   ( z )
  * ( 0  M    ) * ( x )
  * ( 0       )   ( y )
+ * </pre>
+ * or (with translation)
+ * <pre>
+ * ( 1  0  0 )   ( z )
+ * (    M    ) * ( x )
+ * (         )   ( y )
  * </pre>
  * </dd>
  * <dt><b><tt>type:"generic"</tt></b></dt><dd><b>a, b, c, d, e, f, g, h, i</b> Nine matrix entries (numbers or functions)
@@ -1490,7 +1607,7 @@ JXG.registerElement('transform', JXG.createTransform);
  * <dt><b><tt>type:"rotateZ"</tt></b></dt><dd><b>a, [p=[0,0,0]]</b> angle (in radians), [point].
  * Rotate with angle a around the normal vector (0, 0, 1) through the point p.
  * </dd>
- * <dt><b><tt>type:"affine"</tt></b></dt><dd><b>a,b,...,i</b> generic affine transformation (9 parameters, numbers or functions).
+ * <dt><b><tt>type:"affine"</tt></b></dt><dd><b>a,b,...,i (, j ,k, l)</b> generic affine transformation (9 or 12 parameters, numbers or functions).
  * The full transformation matrix has the form
  * <pre>
  * ( 1  0  0  0 )   ( w )
@@ -1498,14 +1615,28 @@ JXG.registerElement('transform', JXG.createTransform);
  * ( 0  d  e  f )   ( y )
  * ( 0  g  h  i )   ( z )
  * </pre>
+ * or (with translation)
+ * <pre>
+ * ( 1  0  0  0 )   ( w )
+ * ( a  b  c  d ) * ( x )
+ * ( e  f  g  h )   ( y )
+ * ( i  j  k  l )   ( z )
+ * </pre>
  * </dd>
- * <dt><b><tt>type:"affinematrix"</tt></b></dt><dd><b>M</b> generic affine 3x3 transformation matrix (containing numbers or functions).
+ * <dt><b><tt>type:"affinematrix"</tt></b></dt><dd><b>M</b> generic affine 3x3 or 3x4 transformation matrix (containing numbers or functions).
  * The full transformation matrix has the form
  * <pre>
  * ( 1  0  0  0 )   ( w )
  * ( 0          ) * ( x )
  * ( 0     M    )   ( y )
  * ( 0          )   ( z )
+ * </pre>
+ * or (with translation)
+ * <pre>
+ * ( 1  0  0  0 )   ( w )
+ * (            ) * ( x )
+ * (     M      )   ( y )
+ * (            )   ( z )
  * </pre>
  * </dd>
  * <dt><b><tt>type:"generic"</tt></b></dt><dd><b>a,b,...,p</b> generic transformation (16 parameters, numbers or functions).

--- a/src/base/transformation.js
+++ b/src/base/transformation.js
@@ -56,6 +56,7 @@ import Type from "../utils/type.js";
  * <li> 'shear'
  * <li> 'affine'
  * <li> 'affinematrix'
+ * <li> 'twofingers'
  * <li> 'generic'
  * <li> 'matrix'
  * </ul>
@@ -117,6 +118,17 @@ import Type from "../utils/type.js";
  * ( 1  0  0 )   ( z )
  * ( M       ) * ( x )
  * (         )   ( y )
+ * </pre>
+ *
+ * <p>A 'twofingers' transformation consists of 4 parameters: <ul>
+ * <li>translation in directions x and y (tx, ty),</li>
+ * <li>scaling (s) equally in both the x and y directions and</li>
+ * <li>rotation with angle r (in Radians)</li>
+ * </ul>
+ * <pre>
+ * ( 1    0          0        )   ( z )
+ * ( tx   s*cos(r)  -s*sin(r) ) * ( x )
+ * ( ty   s*sin(r)   s*cos(r) )   ( y )
  * </pre>
  *
  * <p>Generic transformation (9 parameters):
@@ -199,6 +211,7 @@ JXG.extend(
          *                        'shear',
          *                        'affine',
          *                        'affinematrix',
+         *                        'twofingers',
          *                        'generic',
          *                        'matrix'.
          * @param {Array} params Parameters for the various transformation types.
@@ -271,6 +284,17 @@ JXG.extend(
          * (         )   ( y )
          * </pre>
          *
+         * <p>A 'twofingers' transformation consists of 4 parameters: <ul>
+         * <li>translation in directions x and y (tx, ty),</li>
+         * <li>scaling (s) equally in both the x and y directions</li>
+         * <li>rotation with angle r (in Radians)</li>
+         * </ul>
+         * <pre>
+         * ( 1    0          0        )   ( z )
+         * ( tx   s*cos(r)  -s*sin(r) ) * ( x )
+         * ( ty   s*sin(r)   s*cos(r) )   ( y )
+         * </pre>
+         *
          * <p>Generic transformation (9 parameters):
          * <pre>
          * ( a  b  c )   ( z )
@@ -304,6 +328,7 @@ JXG.extend(
                 'shear',
                 'affine',
                 'affinematrix',
+                'twofingers',
                 'generic',
                 'matrix'
             ].includes(type)) {
@@ -497,6 +522,27 @@ JXG.extend(
                 } else {
                     throw new Error("JSXGraph: transformation of type 'affinematrix' needs a 2x2 or a 2x3 matrix as parameter.");
                 }
+            } else if (type === 'twofingers') {
+                if (params.length !== 4) {
+                    throw new Error("JSXGraph: 'twofingers' transformation needs 4 parameters.");
+                }
+
+                this.evalParam = Type.createEvalFunction(board, params, 4);
+                this.update = function () {
+                    var tx = this.evalParam(0),
+                        ty = this.evalParam(1),
+                        s = this.evalParam(2),
+                        r = this.evalParam(3),
+                        co = Math.cos(r),
+                        si = Math.sin(r);
+
+                    this.matrix[1][0] = tx;
+                    this.matrix[1][1] = s * co;
+                    this.matrix[1][2] = -s * si;
+                    this.matrix[2][0] = ty;
+                    this.matrix[2][1] = s * si;
+                    this.matrix[2][2] = s * co;
+                };
             } else if (type === 'generic') {
                 if (params.length !== 9) {
                     throw new Error("JSXGraph: generic transformation needs 9 parameters.");
@@ -1069,6 +1115,7 @@ JXG.extend(
                 'scale',
                 'affine',
                 'affinematrix',
+                'twofingers', // is reversible because sx = sy
                 'generic',
                 'matrix'
                 // 'rotate' is handled separately
@@ -1154,6 +1201,7 @@ JXG.extend(
  * <li> 'shear'
  * <li> 'affine'
  * <li> 'affinematrix'
+ * <li> 'twofingers'
  * <li> 'generic'
  * <li> 'matrix'
  * </ul>
@@ -1228,6 +1276,18 @@ JXG.extend(
  * ( 1  0  0 )   ( z )
  * (    M    ) * ( x )
  * (         )   ( y )
+ * </pre>
+ * </dd>
+ * <dt><b><tt>type:"twofingers"</tt></b></dt><dd> <b>tx, ty, s, r</b> The parameters are <ul>
+ * <li>translation in directions x and y (tx, ty; numbers or functions),</li>
+ * <li>scaling equally in both the x and y directions (s; numbers or functions) and</li>
+ * <li>rotation with angle r (in Radians; number or function)</li>
+ * </ul>
+ * The transformation matrix has the form:
+ * <pre>
+ * ( 1    0          0        )   ( z )
+ * ( tx   s*cos(r)  -s*sin(r) ) * ( x )
+ * ( ty   s*sin(r)   s*cos(r) )   ( y )
  * </pre>
  * </dd>
  * <dt><b><tt>type:"generic"</tt></b></dt><dd><b>a, b, c, d, e, f, g, h, i</b> Nine matrix entries (numbers or functions)

--- a/src/options.js
+++ b/src/options.js
@@ -2144,6 +2144,18 @@ JXG.Options = {
         lineCap: 'butt',
 
         /**
+         * If this is set to true, transform.meltTo(this) will only melt the nre transformation,
+         * if it has the same time as the last one. If not, it is bound to this.
+         *
+         * <b>We highly recommend to use the default value.</b>
+         *
+         * @type Boolean
+         * @default false
+         * @see JXG.Transformation#meltTo
+         */
+        meltOnlySameTransformationType: false,
+
+        /**
          * If this is set to true, the element is updated in every update
          * call of the board. If set to false, the element is updated only after
          * zoom events or more generally, when the bounding box has been changed.

--- a/src/options.js
+++ b/src/options.js
@@ -1451,7 +1451,9 @@ JXG.Options = {
          *   needShift: true,  // mouse wheel zooming needs pressing of the shift key
          *   min: 0.001,       // minimal values of {@link JXG.Board#zoomX} and {@link JXG.Board#zoomY}, limits zoomOut
          *   max: 1000.0,      // maximal values of {@link JXG.Board#zoomX} and {@link JXG.Board#zoomY}, limits zoomIn
-         *   center: 'auto',   // 'auto': the center of zoom is at the position of the mouse or at the midpoint of two fingers
+         *   center: 'auto',   // 'auto' or 'center': the center of zoom is at the position of the mouse or at the midpoint of two fingers
+         *                     // 'first': the center of zoom is at the position of the mouse or of the first finger
+         *                     // 'second': the center of zoom is at the position of the mouse or of the second finger
          *                     // 'board': the center of zoom is at the board's center
          *   pinch: true,      // pinch-to-zoom gesture for proportional zoom
          *   pinchHorizontal: true, // Horizontal pinch-to-zoom zooms horizontal axis. Only available if keepaspectratio:false

--- a/src/utils/type.js
+++ b/src/utils/type.js
@@ -444,6 +444,7 @@ JXG.extend(
                 return f[k]();
             };
             func.deps = deps;
+            func.n = n;
 
             return func;
         },


### PR DESCRIPTION
This is one of multiple PR to improve transformations and twoFingerMove. **It should be merged after #816!**

This PR does:

- add **new transformation type `twofingers`**
- add **method `getParams`** to transformations
- Add **new function `board.getTwoFingerTransforms`** and mark `board.getTwoFingerTransform` as deprecated.  
  The result of the new function can be used to create transformation(s) that represent the movement.
  - generic:
    ```js
    [1, 0, 0,
     tx, sx*cos(r), -sy*sin(r),
     ty, sx*cos(r),  sy*cos(r)]
    ```
  - affine:
    ```js
    [tx, sx*cos(r), -sy*sin(r),
     ty, sx*cos(r),  sy*cos(r)]
    ```
  - twofingers:
    ```js
    [tx, ty, s, r]
    ```
  - translation * scale * rotation:  
    Translation: `[tx, ty]`  
    Scale: `[sx, sy]`  
    Rotation: `[r]`
- add attribute **`touches` to every move event**
- source out **pinch recognition** and calculations from `board.gestureChangeListener` to new function `board.twoFingerGesture` and initiate private attributes via `board.twoFingerGestureStart`  
  call `board.twoFingerGestureStart` on every two finger gesture
- propagate event to `board.twoFingerTouchObject` and `board.twoFingerTouchCircle`
- use for attribute `zoom.center === 'auto'` the **real center between both fingers**  
  Previously, the position of the first finger was used. Now, the actual center point is used. `zoom.center` now also has the options `first` and `second`.


This PR is complete and ready to be merged, although one or two more PRs on the topic of "Transformations & twoFingerMove" will follow in the coming days.