### PR TITLE
add two missing interfaces

### DIFF
--- a/src/base/board.js
+++ b/src/base/board.js
@@ -6705,11 +6705,10 @@ JXG.extend(
                 }
                 switch (key) {
                     case 'axis':
-                        if (value === false) {
-                            if (Type.exists(this.defaultAxes)) {
-                                this.defaultAxes.x.setAttribute({ visible: false });
-                                this.defaultAxes.y.setAttribute({ visible: false });
-                            }
+                        if (Type.exists(this.defaultAxes)) {
+                            this.defaultAxes.x.setAttribute({ visible: value });
+                            this.defaultAxes.y.setAttribute({ visible: value });
+                            this.attr['axis'] = value;
                         } else {
                             // TODO
                         }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3654,6 +3654,12 @@ declare namespace JXG {
         arrow?: ArrowOptions;
     }
 
+    export interface Circle3D extends GeometryElement{
+        center(): Point3D;
+        normal(): number[];
+        radius(): number;
+    }
+
     export interface Circle3DAttributes extends GeometryElementAttributes {}
 
     export interface Curve3DAttributes extends CurveAttributes {}
@@ -3678,6 +3684,17 @@ declare namespace JXG {
         X(): number;
         Y(): number;
         Z(): number;
+    }
+
+    export interface Polygon3D {
+        vertices(): Point3D[];
+    }
+
+    export interface Polygon3DAttributes extends GeometryElementAttributes {}
+
+    export interface Sphere3D {
+        center(): Point3D;
+        radius(): number;
     }
 
     export interface Sphere3DAttributes extends GeometryElementAttributes {}


### PR DESCRIPTION
Dear Alfred,

Not sure if something changed, but I am getting new error messages about missing interfaces in `src/index.d.ts` when I use JSXGraph from NPM (ie: from node_modules).   `Circle3D` and `Polygon3D` are not defined.

This PR adds them; the minimum changes to make the errors go away.

I have never figured out how to use that TypeScript declaration file; it doesn't seem useful.  The easier fix might be to remove it from the project.   I'd love to contribute the `Simplified JSXGraph` version to the project.