### PR TITLE
cleared a /TODO for board.setAttribute()

### DIFF
--- a/src/base/board.js
+++ b/src/base/board.js
@@ -6705,13 +6705,18 @@ JXG.extend(
                 }
                 switch (key) {
                     case 'axis':
-                        if (value === false) {
-                            if (Type.exists(this.defaultAxes)) {
-                                this.defaultAxes.x.setAttribute({ visible: false });
-                                this.defaultAxes.y.setAttribute({ visible: false });
-                            }
+                        if (Type.exists(this.defaultAxes)) {
+                            this.defaultAxes.x.setAttribute({ visible: value });
+                            this.defaultAxes.y.setAttribute({ visible: value });
+                            this.attr[key] = value;
                         } else {
-                            // TODO
+                            if (value === true) {
+                                // create the default axis
+                                this.defaultAxes = {};
+                                this.defaultAxes.x = board.create("axis", [[0, 0], [1, 0]]);
+                                this.defaultAxes.y = board.create("axis", [[0, 0], [0, 1]]);
+                                this.attr[key] = true;
+                            }
                         }
                         break;
                     case 'cssstyle':

--- a/src/base/board.js
+++ b/src/base/board.js
@@ -6713,13 +6713,13 @@ JXG.extend(
                             if (value === true) {
                                 // create the default axis
                                 this.defaultAxes = {};
-                                this.defaultAxes.x = board.create("axis", [[0, 0], [1, 0]]);
-                                this.defaultAxes.y = board.create("axis", [[0, 0], [0, 1]]);
+                                this.defaultAxes.x = this.create("axis", [[0, 0], [1, 0]]);
+                                this.defaultAxes.y = this.create("axis", [[0, 0], [0, 1]]);
                                 this.attr[key] = true;
                             }
                         }
                         break;
-                    case 'cssstyle':
+                case 'cssstyle':
                         lst = Type.css2js(value);
                         node = this.containerObj;
                         // node = this.renderer.svgRoot;


### PR DESCRIPTION
Dear Alfred,

I was struggling with `board.setAttribute({axis:true})`, which I needed for a little game.  So I looked into the code and it was marked as '\\\\ TODO'.  

This is a minimum implementation to support  true/false.  It doesn't handle the more complex cases. described in [https://jsxgraph.org/docs/symbols/JXG.Board.html#axis](https://jsxgraph.org/docs/symbols/JXG.Board.html#axis)

Here's a test program:
~~~
<!DOCTYPE html>
<html>

<head>
    <title>Test Axis Attribute</title>
    <meta http-equiv="content-type" content="text/html; charset=utf-8">
    <link rel="stylesheet" type="text/css" href="jsxgraph/distrib/jsxgraph.css" />
    <script type="text/javascript" src="jsxgraph/distrib/jsxgraphcore.js"></script>
</head>

<body>
    <div id="jxgbox" class="jxgbox" style="width:800px; height:800px; float:left"></div>
    <script type="text/javascript">
        var board = JXG.JSXGraph.initBoard('jxgbox') 
        board.create('button', [-2, -2, 'Axis - On', function () { board.setAttribute({ axis: true }) }])
        board.create('button', [2, -2, 'Axis - Off', function () { board.setAttribute({ axis: false }) }])
    </script>
</body>

</html>