### PR TITLE
Fix media query listener cleanup

### DIFF
--- a/src/base/board.js
+++ b/src/base/board.js
@@ -2114,8 +2114,11 @@ JXG.extend(
                 // we need to call the listener when having @media: print.
                 try {
                     // window.matchMedia('print').addEventListener('change', this.printListenerMatch.apply(this, arguments));
-                    window.matchMedia('print').addEventListener('change', this.printListenerMatch.bind(this));
-                    window.matchMedia('screen').addEventListener('change', this.printListenerMatch.bind(this));
+                    this.printListenerMatchBound = this.printListenerMatch.bind(this);
+                    this.printMediaQuery = window.matchMedia('print');
+                    this.screenMediaQuery = window.matchMedia('screen');
+                    this.printMediaQuery.addEventListener('change', this.printListenerMatchBound);
+                    this.screenMediaQuery.addEventListener('change', this.printListenerMatchBound);
                     this.resizeHandlers.push('print');
                 } catch (err) {
                     JXG.debug("Error adding printListener", err);
@@ -2165,8 +2168,11 @@ JXG.extend(
                             Env.removeEvent(window, 'scroll', this.scrollListener, this);
                             break;
                         case 'print':
-                            window.matchMedia('print').removeEventListener('change', this.printListenerMatch.bind(this), false);
-                            window.matchMedia('screen').removeEventListener('change', this.printListenerMatch.bind(this), false);
+                            this.printMediaQuery.removeEventListener('change', this.printListenerMatchBound, false);
+                            this.screenMediaQuery.removeEventListener('change', this.printListenerMatchBound, false);
+                            this.printMediaQuery = null;
+                            this.screenMediaQuery = null;
+                            this.printListenerMatchBound = null;
                             break;
                         // case 'afterprint':
                         //     Env.removeEvent(window, 'afterprint', this.printListener, this);

--- a/test/testBoard.js
+++ b/test/testBoard.js
@@ -60,6 +60,43 @@ describe("Test board handling", function() {
         JXG.JSXGraph.freeBoard(board);
     });
 
+    it("removes print media query listeners with the registered callback", function() {
+        var mediaQueries = {}, testBoard,
+            container = document.createElement('div');
+
+        container.id = 'print-listener-board';
+        container.style.width = '100px';
+        container.style.height = '100px';
+        document.body.appendChild(container);
+        spyOn(window, 'matchMedia').and.callFake(function(query) {
+            mediaQueries[query] = {
+                addEventListener: jasmine.createSpy('addEventListener'),
+                removeEventListener: jasmine.createSpy('removeEventListener')
+            };
+            return mediaQueries[query];
+        });
+
+        testBoard = JXG.JSXGraph.initBoard(container.id, {
+            axis: false,
+            grid: false,
+            boundingbox: [-5, 5, 5, -5],
+            showCopyright: false,
+            showNavigation: false
+        });
+        JXG.JSXGraph.freeBoard(testBoard);
+
+        ['print', 'screen'].forEach(function(query) {
+            var mediaQuery = mediaQueries[query],
+                registeredCallback = mediaQuery.addEventListener.calls.mostRecent().args[1];
+
+            expect(mediaQuery.removeEventListener).toHaveBeenCalledWith(
+                'change',
+                registeredCallback,
+                false
+            );
+        });
+        container.remove();
+    });
+
 
 });
-


### PR DESCRIPTION
## Summary

- retain the print and screen MediaQueryList instances created for each board
- reuse the exact bound callback when removing their change listeners
- clear the retained references after board teardown
- add a regression test covering listener identity during freeBoard

## Root cause

The resize setup and teardown paths each called Function.prototype.bind independently. Since bind returns a new function, removeEventListener never received the callback that had originally been registered. In long-lived applications that repeatedly create and free boards, MediaQueryList kept disposed boards reachable through the registered callback.

In a reproducer that repeatedly switched between board-backed scenes, the retained JSXGraph Board count grew from 16 to 66 after 50 cycles. With this change it stayed stable at 1 across the same 50-cycle check.

## Validation

- ChromeHeadless Karma suite: 331/331 passing
- Browser heap snapshot comparison after 50 board lifecycle cycles: Board count 1 -> 1

Note: the aggregate npm test command reaches the build successfully on macOS but its Makefile then invokes GNU-style sed -i, which BSD sed rejects. The Karma suite was therefore run directly after the successful webpack build.