### PR TITLE
Add missing 3D TypeScript declarations

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3656,6 +3656,12 @@ declare namespace JXG {
 
     export interface Circle3DAttributes extends GeometryElementAttributes {}
 
+    export interface Circle3D extends GeometryElement {
+        center: Point3D;
+        Radius(value?: number): number;
+        setRadius(radius: string | number | (() => number)): this;
+    }
+
     export interface Curve3DAttributes extends CurveAttributes {}
 
     export interface Curve3D extends Curve {}
@@ -3680,7 +3686,23 @@ declare namespace JXG {
         Z(): number;
     }
 
+    export interface Polygon3DAttributes extends GeometryElementAttributes {}
+
+    export interface Polygon3D extends GeometryElement {
+        vertices: Point3D[];
+    }
+
     export interface Sphere3DAttributes extends GeometryElementAttributes {}
+
+    export interface Sphere3D extends GeometryElement {
+        center: Point3D;
+        point2: Point3D | null;
+        Radius(value?: number): number;
+        setRadius(radius: string | number | (() => number)): this;
+        X(u: number, v: number): number;
+        Y(u: number, v: number): number;
+        Z(u: number, v: number): number;
+    }
 
     export interface View3DAttributes extends GeometryElementAttributes {
         axesPosition?: "center";


### PR DESCRIPTION
*This code and PR description is from a coding agent.*

## Summary

- Declare the missing `Circle3D`, `Polygon3DAttributes`, `Polygon3D`, and `Sphere3D` interfaces already referenced by `View3D.create()` overloads.
- Type the existing runtime members for circle centers and radii, polygon vertices, and sphere coordinates.
- Keep the change declaration-only; runtime behavior is unchanged.

## Problem

`src/index.d.ts` references these four names but does not declare them. With library checking enabled, TypeScript therefore reports `TS2304`/`TS2552` while checking JSXGraph's public declarations, even when a consumer does not use the 3D APIs.

The runtime implementations already exist in `src/3d/circle3d.js`, `polygon3d.js`, and `sphere3d.js`. The new interfaces describe those existing objects and make the corresponding `View3D.create()` overloads usable.

## Validation

Using Node 24, matching CI:

- Red/green strict TypeScript 7.0.2 consumer against current `main` and the packed patched package
- `npm run eslint`
- Both core Webpack builds completed successfully
- Karma browser suite: 332 tests passed in Chrome Headless
- `npm pack` followed by a strict packed-package consumer check
- `git diff --check`

The repository-wide Prettier check currently reports the existing 132-file formatting baseline, so this PR does not include unrelated formatting changes.