### PR TITLE
Fix resource ID collisions for anonymous containers

### DIFF
--- a/src/jsxgraph.js
+++ b/src/jsxgraph.js
@@ -125,7 +125,7 @@ JXG.JSXGraph = {
      * @private
      */
     initRenderer: function (box, dim, doc, attrRenderer) {
-        var boxid, renderer;
+        var boxid, renderer, containerId;
 
         // Former version:
         // doc = doc || document
@@ -135,6 +135,17 @@ JXG.JSXGraph = {
 
         if (typeof doc === "object" && box !== null) {
             boxid = (Type.isString(box)) ? doc.getElementById(box) : box;
+
+            // SVG renderer resource names use the container ID as their prefix. Generate one
+            // before constructing the renderer so anonymous element references cannot create
+            // duplicate clip paths, filters, or navigation IDs.
+            if (boxid && !boxid.id) {
+                containerId = 1;
+                while (doc.getElementById("jxgbox" + containerId)) {
+                    containerId += 1;
+                }
+                boxid.id = "jxgbox" + containerId;
+            }
 
             // Remove everything from the container before initializing the renderer and the board
             while (boxid.firstChild) {

--- a/test/testBoard.js
+++ b/test/testBoard.js
@@ -98,5 +98,42 @@ describe("Test board handling", function() {
         container.remove();
     });
 
+    it("assigns unique IDs to anonymous board containers", function() {
+        var firstBoard, secondBoard,
+            firstContainer = document.createElement('div'),
+            secondContainer = document.createElement('div'),
+            attributes = {
+                renderer: 'svg',
+                axis: false,
+                grid: false,
+                boundingbox: [-5, 5, 5, -5],
+                resize: {enabled: false},
+                showCopyright: false,
+                showNavigation: false
+            };
+
+        firstContainer.style.width = '100px';
+        firstContainer.style.height = '100px';
+        secondContainer.style.width = '100px';
+        secondContainer.style.height = '100px';
+        document.body.appendChild(firstContainer);
+        document.body.appendChild(secondContainer);
+
+        firstBoard = JXG.JSXGraph.initBoard(firstContainer, attributes);
+        secondBoard = JXG.JSXGraph.initBoard(secondContainer, attributes);
+
+        expect(firstContainer.id).not.toEqual('');
+        expect(secondContainer.id).not.toEqual('');
+        expect(firstContainer.id).not.toEqual(secondContainer.id);
+        expect(firstContainer.querySelector('clipPath').id).not.toEqual(
+            secondContainer.querySelector('clipPath').id
+        );
+
+        JXG.JSXGraph.freeBoard(firstBoard);
+        JXG.JSXGraph.freeBoard(secondBoard);
+        firstContainer.remove();
+        secondContainer.remove();
+    });
+
 
 });


### PR DESCRIPTION
*This code and PR description is from a coding agent.*

## Summary

Assign a collision-free DOM ID before constructing a renderer for an anonymous board container, and add a focused browser regression for two anonymous SVG boards.

## Problem

`SVGRenderer` prefixes reusable resource IDs with `container.id`. When `initBoard()` receives multiple `HTMLElement` objects without IDs, each renderer creates names such as `_ClipFull`. Later document-wide ID lookups can then update the first board's clip path while resizing another board, which can make content disappear.

## Fix

`initRenderer()` now assigns the first unused `jxgboxN` ID when the resolved container has no ID. Existing user-supplied IDs are unchanged, while the renderer and subsequent `Board` construction see the same generated ID.

The regression initializes two anonymous element references and checks that their generated container IDs and SVG clip-path IDs are non-empty and distinct.

## Testing

- Red on current `main`: the new Jasmine test failed with two empty container IDs and duplicate `_ClipFull` IDs (1 failed, 332 passed).
- Green with this change: all 333 Karma/Jasmine browser tests pass in Chrome Headless using Node 24.
- Both JavaScript and ES module core bundles build successfully with Node 24.
- The compressor build and the project's ESLint source-file set pass.
- A packed-package Vite 8 fixture built with Bun 1.4 passes in Chromium: `jxgbox1_ClipFull` remains 320 × 200 and `jxgbox2_ClipFull` is 180 × 120.

On macOS, the core build and Karma command were run directly because the Makefile wrapper's `sed -i` invocation assumes GNU sed.